### PR TITLE
Bump version

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "SSLClient",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository":
   {
     "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SSLClient
-version=1.0
+version=1.1
 author=V Govorovski
 maintainer=Github Community
 sentence=Provides secure network connection over a generic Client trasport object.


### PR DESCRIPTION
PlatformIO and ArduinoIDEs won't fetch the new version based on commits, bumping to a new version is necessary. This keeps the existing projects from erroring out due to the latest mbedTLS issue which was fixed in the last pull request #19 .


Thanks for the library!