### PR TITLE
Update ssl_client.cpp

### DIFF
--- a/src/ssl_client.cpp
+++ b/src/ssl_client.cpp
@@ -18,7 +18,7 @@
 //#include <esp32-hal-log.h>
 
 
-#if !defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED) && !defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
+#if !defined(MBEDTLS_KEY_EXCHANGE_SOM_PSK_ENABLED) && !defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 #  error "Please configure IDF framework to include mbedTLS -> Enable pre-shared-key ciphersuites and activate at least one cipher"
 #endif
 

--- a/src/ssl_client.cpp
+++ b/src/ssl_client.cpp
@@ -18,7 +18,7 @@
 //#include <esp32-hal-log.h>
 
 
-#if !defined(MBEDTLS_KEY_EXCHANGE_SOM_PSK_ENABLED) && !defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
+#if !defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 #  error "Please configure IDF framework to include mbedTLS -> Enable pre-shared-key ciphersuites and activate at least one cipher"
 #endif
 


### PR DESCRIPTION
A bugfix to allow compilation in PlatformIO. The following error was recurring: #error "Please configure IDF framework to include mbedTLS -> Enable pre-shared-key ciphersuites and activate at least one cipher" #error "Please configure IDF framework to include mbedTLS -> Enable pre-shared-key ciphersuites and activate at least one cipher" Variable renamed to MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED