### PR TITLE
Allow Setting the client after Initialisation

### DIFF
--- a/src/SSLClient.cpp
+++ b/src/SSLClient.cpp
@@ -194,7 +194,7 @@ int SSLClient::read(uint8_t *buf, size_t size)
         buf++;
         peeked = 1;
     }
-    
+
     int res = get_ssl_receive(sslclient, buf, size);
     if (res < 0) {
         stop();
@@ -317,4 +317,8 @@ int SSLClient::lastError(char *buf, const size_t size)
 void SSLClient::setHandshakeTimeout(unsigned long handshake_timeout)
 {
     sslclient->handshake_timeout = handshake_timeout * 1000;
+}
+
+void SSLClient::setClient(Client* client){
+    sslclient->client = client;
 }

--- a/src/SSLClient.h
+++ b/src/SSLClient.h
@@ -26,7 +26,7 @@ class SSLClient : public Client
 {
 protected:
     sslclient_context *sslclient;
- 
+
     int _lastError = 0;
 	int _peek = -1;
     int _timeout = 0;
@@ -74,6 +74,8 @@ public:
     bool loadPrivateKey(Stream& stream, size_t size);
     bool verify(const char* fingerprint, const char* domain_name);
     void setHandshakeTimeout(unsigned long handshake_timeout);
+    void setClient(Client* client);
+
 
     int setTimeout(uint32_t seconds){ return 0; }
 


### PR DESCRIPTION
I had a use case where I couldn't set the transport client when the sslclient object was created, 
(the transport socket didn't exist yet and at that point, the software hasnt even decided kind of Client object it is yet (e.g. wificlient, gsmclient, etc))

So this fork allows you to create the client, then later set the transport socket.

example:
```c++
Client *createclient(); //user function to create client

Client *transport = NULL;
SSLClient net = SSLClient();

void init(){
  transport = createclient(); //create transport object and store pointer
  net.setClient(transport); //set the client
  //use net
}
```

Not sure if this would need extra checks to stop changing the transport socket after its opened, 
But in my project, I'm simply choosing to only call it when its not open