### PR TITLE
Added some commits latest of WifiSecureClient to fix some bugs.

### DIFF
--- a/Release Note.md
+++ b/Release Note.md
@@ -1,0 +1,6 @@
+SSL Client V2.0.0 Updates:
+
+1. Added some commits of WifiSecureClient to fix some bugs.
+2. Change send_ssl_data to use size_t instead of uint16_t - Commit a299ddc
+3. ssl_client.cpp: Fix parameter name in _handle_error - commit : 39155e7
+4. Fix memory leaks when SSL/TLS connection fails, Commit : f29f448

--- a/src/ssl_client.cpp
+++ b/src/ssl_client.cpp
@@ -353,7 +353,7 @@ int data_to_read(sslclient_context *ssl_client)
 }
 
 
-int send_ssl_data(sslclient_context *ssl_client, const uint8_t *data, uint16_t len)
+int send_ssl_data(sslclient_context *ssl_client, const uint8_t *data, size_t len)
 {
     log_d("Writing SSL (%d bytes)...", len);  //for low level debug
     int ret = -1;

--- a/src/ssl_client.cpp
+++ b/src/ssl_client.cpp
@@ -24,7 +24,7 @@
 
 const char *pers = "esp32-tls";
 
-static int _handle_error(int err, const char * file, int line)
+static int _handle_error(int err, const char * function, int line)
 {
     if(err == -30848){
         return err;
@@ -32,9 +32,9 @@ static int _handle_error(int err, const char * file, int line)
 #ifdef MBEDTLS_ERROR_C
     char error_buf[100];
     mbedtls_strerror(err, error_buf, 100);
-    log_e("[%s():%d]: (%d) %s", file, line, err, error_buf);
+    log_e("[%s():%d]: (%d) %s", function, line, err, error_buf);
 #else
-    log_e("[%s():%d]: code %d", file, line, err);
+    log_e("[%s():%d]: code %d", function, line, err);
 #endif
     return err;
 }

--- a/src/ssl_client.h
+++ b/src/ssl_client.h
@@ -36,7 +36,7 @@ void ssl_init(sslclient_context *ssl_client, Client *client);
 int start_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t port, int timeout, const char *rootCABuff, const char *cli_cert, const char *cli_key, const char *pskIdent, const char *psKey);
 void stop_ssl_socket(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key);
 int data_to_read(sslclient_context *ssl_client);
-int send_ssl_data(sslclient_context *ssl_client, const uint8_t *data, uint16_t len);
+int send_ssl_data(sslclient_context *ssl_client, const uint8_t *data, size_t len);
 int get_ssl_receive(sslclient_context *ssl_client, uint8_t *data, int length);
 bool verify_ssl_fingerprint(sslclient_context *ssl_client, const char* fp, const char* domain_name);
 bool verify_ssl_dn(sslclient_context *ssl_client, const char* domain_name);


### PR DESCRIPTION
SSL Client V2.0.0 Updates:

1. Added some commits of WifiSecureClient to fix some bugs.
2. Change send_ssl_data to use size_t instead of uint16_t - Commit a299ddc
3. ssl_client.cpp: Fix parameter name in _handle_error - commit : 39155e7
4. Fix memory leaks when SSL/TLS connection fails, Commit : f29f448