### PR TITLE
client_net_send should return an error in case write fails.

### DIFF
--- a/src/ssl_client.cpp
+++ b/src/ssl_client.cpp
@@ -132,6 +132,10 @@ static int client_net_send( void *ctx, const unsigned char *buf, size_t len ) {
     //esp_log_buffer_hexdump_internal("SSL.WR", buf, (uint16_t)len, ESP_LOG_VERBOSE);
     
     int result = client->write(buf, len);
+    if (result == 0) {
+        log_e("write failed");
+        result= MBEDTLS_ERR_NET_SEND_FAILED;
+    }
     
     log_d("SSL client TX res=%d len=%d", result, len);
     return result;


### PR DESCRIPTION
Returning 0 mbedtsl assumes all buf content has been written.