### PR TITLE
Check for null pointer before to call client stop method

### DIFF
--- a/src/SSLClient.cpp
+++ b/src/SSLClient.cpp
@@ -61,11 +61,8 @@ SSLClient::~SSLClient()
 
 void SSLClient::stop()
 {
-    if (sslclient->client >= 0) {
-        //sslclient->client->stop();
-        _connected = false;
-        _peek = -1;
-    }
+    _connected = false;
+    _peek = -1;
     stop_ssl_socket(sslclient, _CA_cert, _cert, _private_key);
 }
 

--- a/src/ssl_client.cpp
+++ b/src/ssl_client.cpp
@@ -335,8 +335,8 @@ int start_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t p
 void stop_ssl_socket(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key)
 {
     log_v("Cleaning SSL connection.");
-
-    ssl_client->client->stop();
+    if (ssl_client->client != NULL) 
+        ssl_client->client->stop();
 
     // avoid memory leak if ssl connection attempt failed
     if (ssl_client->ssl_conf.ca_chain != NULL) {


### PR DESCRIPTION
Added check to verify if the pointer to the underlaying client is not null before to call the stop method.
