### PR TITLE
Fix stop() function calls to stop_ssl_socket()

### DIFF
--- a/src/SSLClient.cpp
+++ b/src/SSLClient.cpp
@@ -59,14 +59,19 @@ SSLClient::~SSLClient()
     delete sslclient;
 }
 
-void SSLClient::stop()
-{
-    if (sslclient->client >= 0) {
-        //sslclient->client->stop();
-        _connected = false;
-        _peek = -1;
+void SSLClient::stop() {
+    if (sslclient->client != nullptr) {
+        if (sslclient->client >= 0) {
+            log_v("Stopping ssl client");
+            stop_ssl_socket(sslclient, _CA_cert, _cert, _private_key);
+        } else {
+            log_v("stop() not called because client is < 0");
+        }
+    } else {
+        log_v("stop() not called because client is nullptr");
     }
-    stop_ssl_socket(sslclient, _CA_cert, _cert, _private_key);
+     _connected = false;
+    _peek = -1;
 }
 
 int SSLClient::connect(IPAddress ip, uint16_t port)
@@ -98,25 +103,6 @@ int SSLClient::connect(IPAddress ip, uint16_t port, const char *_CA_cert, const 
     return connect(ip.toString().c_str(), port, _CA_cert, _cert, _private_key);
 }
 
-// int SSLClient::connect(const char *host, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key)
-// {
-//     log_d("Connecting to %s:%d", host, port);
-//     if(_timeout > 0){
-//         sslclient->handshake_timeout = _timeout;
-//     }
-//     int ret = start_ssl_client(sslclient, host, port, _timeout, _CA_cert, _cert, _private_key, NULL, NULL);
-//     _lastError = ret;
-//     if (ret < 0) {
-//         log_e("start_ssl_client: %d", ret);
-//         stop();
-//         _connected = false;
-//         return 0;
-//     }
-//     log_i("SSL connection established");
-//     _connected = true;
-//     return 1;
-// }
-
 int SSLClient::connect(const char *host, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key)
 {
     log_d("Connecting to %s:%d", host, port);
@@ -129,15 +115,12 @@ int SSLClient::connect(const char *host, uint16_t port, const char *_CA_cert, co
         log_e("start_ssl_client: %d", ret);
         stop();
         _connected = false;
-        // return the error code instead of just 0
-        return ret;
+        return 0;
     }
     log_i("SSL connection established");
     _connected = true;
-    // consider returning a non-negative code indicating success
-    return 0;
+    return 1;
 }
-
 
 int SSLClient::connect(IPAddress ip, uint16_t port, const char *pskIdent, const char *psKey) {
     return connect(ip.toString().c_str(), port,_pskIdent, _psKey);

--- a/src/SSLClient.cpp
+++ b/src/SSLClient.cpp
@@ -98,6 +98,25 @@ int SSLClient::connect(IPAddress ip, uint16_t port, const char *_CA_cert, const 
     return connect(ip.toString().c_str(), port, _CA_cert, _cert, _private_key);
 }
 
+// int SSLClient::connect(const char *host, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key)
+// {
+//     log_d("Connecting to %s:%d", host, port);
+//     if(_timeout > 0){
+//         sslclient->handshake_timeout = _timeout;
+//     }
+//     int ret = start_ssl_client(sslclient, host, port, _timeout, _CA_cert, _cert, _private_key, NULL, NULL);
+//     _lastError = ret;
+//     if (ret < 0) {
+//         log_e("start_ssl_client: %d", ret);
+//         stop();
+//         _connected = false;
+//         return 0;
+//     }
+//     log_i("SSL connection established");
+//     _connected = true;
+//     return 1;
+// }
+
 int SSLClient::connect(const char *host, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key)
 {
     log_d("Connecting to %s:%d", host, port);
@@ -110,12 +129,15 @@ int SSLClient::connect(const char *host, uint16_t port, const char *_CA_cert, co
         log_e("start_ssl_client: %d", ret);
         stop();
         _connected = false;
-        return 0;
+        // return the error code instead of just 0
+        return ret;
     }
     log_i("SSL connection established");
     _connected = true;
-    return 1;
+    // consider returning a non-negative code indicating success
+    return 0;
 }
+
 
 int SSLClient::connect(IPAddress ip, uint16_t port, const char *pskIdent, const char *psKey) {
     return connect(ip.toString().c_str(), port,_pskIdent, _psKey);


### PR DESCRIPTION
UPDATE: @govorox Your work creating and publishing this library is obviously appreciated by the community. If mainting this is no longer an option for you consider adding another maintainer  or more. As I use this library as a dependency I would be happy to maintain it and address Issues and PR either solo or as one of two or more maintainers.

PULL REQUEST:
When running on an ESP32 I noticed that I was getting `abort()` called due to an exception starting in a connect function. The throw was a null pointer exception when the client had already terminated in advance of the `stop()` function call, or if the client was NULL having not yet been created. This PR additionally checks for `nullptr` and retains the original check for `>=0` . Will ouput Serial with a Verbose log level. 

Closes #21
Closes #13