### PR TITLE
Implement SSLClient::setTimeout, set recv timeout in start_ssl_client()

### DIFF
--- a/src/SSLClient.cpp
+++ b/src/SSLClient.cpp
@@ -371,3 +371,8 @@ void SSLClient::setHandshakeTimeout(unsigned long handshake_timeout)
 void SSLClient::setClient(Client* client){
     sslclient->client = client;
 }
+
+void SSLClient::setTimeout(int milliseconds){ 
+  _timeout = milliseconds; 
+}
+

--- a/src/SSLClient.cpp
+++ b/src/SSLClient.cpp
@@ -372,7 +372,7 @@ void SSLClient::setClient(Client* client){
     sslclient->client = client;
 }
 
-void SSLClient::setTimeout(int milliseconds){ 
+void SSLClient::setTimeout(uint32_t milliseconds){ 
   _timeout = milliseconds; 
 }
 

--- a/src/SSLClient.h
+++ b/src/SSLClient.h
@@ -75,7 +75,9 @@ public:
   bool verify(const char* fingerprint, const char* domain_name);
   void setHandshakeTimeout(unsigned long handshake_timeout);
   void setClient(Client* client);
-  int setTimeout(uint32_t seconds){ return 0; }
+  void setTimeout(uint32_t milliseconds){ 
+    _timeout = milliseconds; 
+  }
 
   operator bool() {
     return connected();

--- a/src/SSLClient.h
+++ b/src/SSLClient.h
@@ -75,9 +75,7 @@ public:
   bool verify(const char* fingerprint, const char* domain_name);
   void setHandshakeTimeout(unsigned long handshake_timeout);
   void setClient(Client* client);
-  void setTimeout(uint32_t milliseconds){ 
-    _timeout = milliseconds; 
-  }
+  void setTimeout(int milliseconds);
 
   operator bool() {
     return connected();

--- a/src/SSLClient.h
+++ b/src/SSLClient.h
@@ -29,7 +29,7 @@ protected:
 
   int _lastError = 0;
 	int _peek = -1;
-  int _timeout = 0;
+  uint32_t _timeout = 0;
   const char *_CA_cert;
   const char *_cert;
   const char *_private_key;
@@ -75,7 +75,7 @@ public:
   bool verify(const char* fingerprint, const char* domain_name);
   void setHandshakeTimeout(unsigned long handshake_timeout);
   void setClient(Client* client);
-  void setTimeout(int milliseconds);
+  void setTimeout(uint32_t milliseconds);
 
   operator bool() {
     return connected();

--- a/src/ssl_client.cpp
+++ b/src/ssl_client.cpp
@@ -334,6 +334,9 @@ int start_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t p
   log_v("Setting up IO callbacks...");
   mbedtls_ssl_set_bio(&ssl_client->ssl_ctx, ssl_client->client,
                       client_net_send, NULL, client_net_recv_timeout );
+  
+  log_v("Setting timeout...");
+  mbedtls_ssl_conf_read_timeout(&ssl_client->ssl_conf,  timeout);
 
   log_v("Performing the SSL/TLS handshake...");
   unsigned long handshake_start_time=millis();

--- a/src/ssl_client.cpp
+++ b/src/ssl_client.cpp
@@ -96,8 +96,8 @@ static int client_net_recv( void *ctx, unsigned char *buf, size_t len ) {
 int client_net_recv_timeout(void *ctx, unsigned char *buf, size_t len, uint32_t timeout) {
   Client *client = (Client*)ctx;
 
-  log_v("Timeout set to %d", timeout);
-  
+  log_v("Timeout set to %u", timeout);
+
   if (!client) { 
     log_e("Uninitialised!");
     return -1;

--- a/src/ssl_client.cpp
+++ b/src/ssl_client.cpp
@@ -96,6 +96,8 @@ static int client_net_recv( void *ctx, unsigned char *buf, size_t len ) {
 int client_net_recv_timeout(void *ctx, unsigned char *buf, size_t len, uint32_t timeout) {
   Client *client = (Client*)ctx;
 
+  log_v("Timeout set to %d", timeout);
+  
   if (!client) { 
     log_e("Uninitialised!");
     return -1;


### PR DESCRIPTION
Implement SSLClient::setTimeout() and use this timeout when starting ssl context (#51)