### PR TITLE
fix: unrequired termination of client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 <!-- [Arduino Libraries Log](https://downloads.arduino.cc/libraries/logs/github.com/govorox/SSLClient/) -->
 
-### Now updated on PlatformIO registry as digitaldragon/SSLClient@1.1.4
-### Updated on Arduino Libraries registry to digitaldragon/GovoroxSSLClient@1.1.4
+### Now updated on PlatformIO registry as digitaldragon/SSLClient@1.1.5
+### Updated on Arduino Libraries registry to digitaldragon/GovoroxSSLClient@1.1.5
 
 # SSLClient Arduino library using *mbedtls* functions
 The SSLClient class implements support for secure connections using TLS (SSL). It Provides a transparent SSL wrapper over existing transport object of a **Client** class.

--- a/Release Note.md
+++ b/Release Note.md
@@ -6,3 +6,4 @@ SSL Client Updates:
 4. Fix memory leaks when SSL/TLS connection fails, Commit : f29f448
 5. Fix buffer issue when writing data larger than receiving buffer, Commit: 4ce6c5f
 6. Fix issue where client read timeout value not being set, Commit: 59ae9f0
+7. Add clarity to return values for start_ssl_client and fix early termination of ssl client, Commit: cc40266

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "SSLClient",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "repository":
   {
     "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=GovoroxSSLClient
-version=1.1.4
+version=1.1.5
 author=V Govorovski
 maintainer=Robert Byrnes <robbyrnes@hotmail.co.uk>
 sentence=Provides secure network connection over a generic Client trasport object.

--- a/src/SSLClient.cpp
+++ b/src/SSLClient.cpp
@@ -24,7 +24,10 @@
 #undef read
 
 /**
- * @brief Construct a new SSLClient::SSLClient object using the default constructor.
+ * @brief Default constructor for the SSLClient class.
+ *
+ * Initializes an SSLClient object with default settings without associating it
+ * to any specific client instance.
  */
 SSLClient::SSLClient() {
   _connected = false;
@@ -39,9 +42,13 @@ SSLClient::SSLClient() {
 }
 
 /**
- * @brief Construct a new SSLClient::SSLClient object using the pointer to the specified client.
- * 
- * @param client 
+ * @brief Constructor for the SSLClient class.
+ *
+ * Initializes an SSLClient object with default settings, binding it to the 
+ * provided client instance.
+ *
+ * @param client Pointer to the client instance the SSLClient should be 
+ *               associated with.
  */
 SSLClient::SSLClient(Client* client) {
   _connected = false;
@@ -56,154 +63,332 @@ SSLClient::SSLClient(Client* client) {
 }
 
 /**
- * @brief Destroy the SSLClient::SSLClient object.
+ * @brief Destructor for the SSLClient class.
+ *
+ * Safely terminates any ongoing SSL connection, releases associated resources,
+ * and deallocates the memory used by the SSL client.
  */
 SSLClient::~SSLClient() {
   stop();
   delete sslclient;
+  sslclient = nullptr;
 }
 
 /**
- * @brief Stops the SSL client.
+ * @brief Terminates the current SSL connection and releases associated resources.
+ *
+ * This function stops the SSL socket and logs relevant information based on the state of 
+ * the client connection. After the SSL connection is terminated, it resets the 
+ * connected flag and peek value of the SSL client.
+ *
+ * @note If the client connection is `nullptr` or its value is less than 0, 
+ *       the SSL socket will not be stopped and a log message will be generated.
  */
 void SSLClient::stop() {
   if (sslclient->client != nullptr) {
     if (sslclient->client >= 0) {
-      log_v("Stopping ssl client");
+      log_i("Stopping ssl client");
       stop_ssl_socket(sslclient, _CA_cert, _cert, _private_key);
     } else {
-      log_v("stop() not called because client is < 0");
+      log_i("stop() not called because client is < 0");
     }
   } else {
-    log_v("stop() not called because client is nullptr");
+    log_i("stop() not called because client is nullptr");
   }
   _connected = false;
   _peek = -1;
 }
 
 /**
- * @brief 
+ * @brief Establishes an SSL connection to the specified IP address and port.
+ *
+ * Based on the class members `_pskIdent` and `_psKey`, this function will decide 
+ * whether to establish a connection using a pre-shared key or using a certificate authority.
+ * If `_pskIdent` and `_psKey` are set, it uses them to establish a connection.
+ * Otherwise, it uses `_CA_cert`, `_cert`, and `_private_key` for the connection.
+ *
+ * @param ip The IP address of the server to connect to.
+ * @param port The port number on the server to connect to.
  * 
- * @param ip 
- * @param port 
- * @return int 
+ * @return Returns 1 if the connection is established successfully, and 0 otherwise.
  */
 int SSLClient::connect(IPAddress ip, uint16_t port) {
   if (_pskIdent && _psKey) {
     log_v("connect with PSK");
     return connect(ip, port, _pskIdent, _psKey);
   }
+
   log_v("connect with CA");
   return connect(ip, port, _CA_cert, _cert, _private_key);
 }
 
+/**
+ * @brief Establishes an SSL connection to the specified IP address and port with a given timeout.
+ *
+ * This function sets the connection timeout and then delegates the connection 
+ * process to the `connect` method that takes `IPAddress` and `port` as its parameters.
+ *
+ * @param ip The IP address of the server to connect to.
+ * @param port The port number on the server to connect to.
+ * @param timeout The timeout duration for the connection, in milliseconds.
+ * 
+ * @return Returns 1 if the connection is established successfully, and 0 otherwise.
+ */
 int SSLClient::connect(IPAddress ip, uint16_t port, int32_t timeout) {
   _timeout = timeout;
   return connect(ip, port);
 }
 
+/**
+ * @brief Establishes an SSL connection to the specified host and port.
+ *
+ * This function determines the type of SSL connection (either with a Pre-Shared Key (PSK) 
+ * or with Certificates (CA)) based on the availability of the PSK identifier and key. 
+ * Depending on which credentials are set, it delegates to the appropriate `connect` variant.
+ *
+ * @param host Pointer to a null-terminated string representing the hostname or IP address 
+ *             of the server to connect to.
+ * @param port The port number on the server to connect to.
+ * 
+ * @return Returns 1 if the connection is established successfully, and 0 otherwise.
+ */
 int SSLClient::connect(const char *host, uint16_t port) {
   if (_pskIdent && _psKey) {
     log_v("connect with PSK");
     return connect(host, port, _pskIdent, _psKey);
   }
+
   log_v("connect with CA");
   return connect(host, port, _CA_cert, _cert, _private_key);
 }
 
+/**
+ * @brief Establishes an SSL connection to the specified host and port with a given timeout.
+ *
+ * This function acts as an overloaded variant of the `connect` function, allowing the caller
+ * to specify a connection timeout value. It then delegates the actual connection process 
+ * to the other variant of the `connect` function.
+ *
+ * @param host    Pointer to a null-terminated string representing the hostname or IP address of the server to connect to.
+ * @param port    The port number on the server to connect to.
+ * @param timeout The timeout value (in milliseconds) for the SSL connection. If the connection is not established
+ *                within this time, the attempt will fail.
+ * 
+ * @return Returns 1 if the connection is established successfully, and 0 otherwise.
+ */
 int SSLClient::connect(const char *host, uint16_t port, int32_t timeout) {
-    _timeout = timeout;
-    return connect(host, port);
-}
-
-int SSLClient::connect(IPAddress ip, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key)
-{
-    return connect(ip.toString().c_str(), port, _CA_cert, _cert, _private_key);
-}
-
-int SSLClient::connect(const char *host, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key)
-{
-    log_d("Connecting to %s:%d", host, port);
-    if(_timeout > 0){
-        sslclient->handshake_timeout = _timeout;
-    }
-    int ret = start_ssl_client(sslclient, host, port, _timeout, _CA_cert, _cert, _private_key, NULL, NULL);
-    _lastError = ret;
-    if (ret < 0) {
-        log_e("start_ssl_client: %d", ret);
-        stop();
-        _connected = false;
-        return 0;
-    }
-    log_i("SSL connection established");
-    _connected = true;
-    return 1;
-}
-
-int SSLClient::connect(IPAddress ip, uint16_t port, const char *pskIdent, const char *psKey) {
-    return connect(ip.toString().c_str(), port,_pskIdent, _psKey);
-}
-
-int SSLClient::connect(const char *host, uint16_t port, const char *pskIdent, const char *psKey) {
-    log_v("start_ssl_client with PSK");
-    if(_timeout > 0){
-        sslclient->handshake_timeout = _timeout;
-    }
-    int ret = start_ssl_client(sslclient, host, port, _timeout, NULL, NULL, NULL, _pskIdent, _psKey);
-    _lastError = ret;
-    if (ret < 0) {
-        log_e("start_ssl_client: %d", ret);
-        stop();
-        return 0;
-    }
-    _connected = true;
-    return 1;
-}
-
-int SSLClient::peek(){
-    if(_peek >= 0){
-        return _peek;
-    }
-    _peek = timedRead();
-    return _peek;
-}
-
-size_t SSLClient::write(uint8_t data)
-{
-    return write(&data, 1);
-}
-
-int SSLClient::read()
-{
-    uint8_t data = -1;
-    int res = read(&data, 1);
-    if (res < 0) {
-        return res;
-    }
-    return data;
-}
-
-size_t SSLClient::write(const uint8_t *buf, size_t size)
-{
-    if (!_connected) {
-        return 0;
-    }
-    int res = send_ssl_data(sslclient, buf, size);
-    if (res < 0) {
-        stop();
-        res = 0;
-    }
-    return res;
+  _timeout = timeout;
+  return connect(host, port);
 }
 
 /**
- * \brief               Reads data from the sslclient. If there is a byte peeked, it returns that byte.
+ * @brief Establishes an SSL connection to the specified IP address and port using a certificate and private key for authentication.
+ *
+ * This function acts as an overloaded variant of the `connect` function, accepting an `IPAddress` object instead of 
+ * a host string. It then delegates the actual connection process to the other variant of the `connect` function.
+ *
+ * @param ip            The IP address of the server to connect to, given as an `IPAddress` object.
+ * @param port          The port number on the server to connect to.
+ * @param _CA_cert      Pointer to a null-terminated string containing the root Certificate Authority (CA) certificate.
+ * @param _cert         Pointer to a null-terminated string containing the client's certificate.
+ * @param _private_key  Pointer to a null-terminated string containing the client's private key.
  * 
- * \param buf           Buffer to read into. 
- * \param size          Size of the buffer.
- * \return int          1 if a byte has been peeked and the client is not connected.
- * \return int          < 1 if client is connected and there is an error from get_ssl_receive().
- * \return int          > 1 if res + peeked. 
+ * @return Returns 1 if the connection is established successfully, and 0 otherwise.
+ */
+int SSLClient::connect(IPAddress ip, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key) {
+  return connect(ip.toString().c_str(), port, _CA_cert, _cert, _private_key);
+}
+
+/**
+ * @brief Establishes an SSL connection to a given server.
+ * 
+ * This function initializes an SSL connection to a server specified by its host and port.
+ * It also accepts optional parameters for CA certificate, client certificate, and client private key for SSL authentication.
+ * The function will log important debugging information like timeout values and whether certificates are provided.
+ * 
+ * @param host          The hostname or IP address of the server.
+ * @param port          The port number on the server to connect to.
+ * @param _CA_cert      Pointer to the CA certificate for server verification. NULL if not provided.
+ * @param _cert         Pointer to the client certificate for client authentication. NULL if not provided.
+ * @param _private_key  Pointer to the private key corresponding to the client certificate. NULL if not provided.
+ * 
+ * @return 1 if the SSL connection is successfully established, 0 otherwise.
+ */
+int SSLClient::connect(const char *host, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key)
+{
+  log_v("Connecting to %s:%d", host, port);
+  log_v("Timeout value: %d", _timeout);
+  log_v("CA Certificate: %s", _CA_cert ? "Provided" : "Not Provided");
+  log_v("Client Certificate: %s", _cert ? "Provided" : "Not Provided");
+  log_v("Private Key: %s", _private_key ? "Provided" : "Not Provided");
+
+  if(_timeout > 0){
+    sslclient->handshake_timeout = _timeout;
+    log_v("Handshake timeout set to: %d", sslclient->handshake_timeout);
+  }
+
+  int ret = start_ssl_client(sslclient, host, port, _timeout, _CA_cert, _cert, _private_key, NULL, NULL);
+  _lastError = ret;
+  log_v("Return value from start_ssl_client: %d", ret);
+
+  if (ret != 1) {
+    log_e("start_ssl_client failed: %d", ret);
+    stop();
+    _connected = false;
+    return 0;
+  }
+
+  log_i("SSL connection established");
+  _connected = true;
+  return 1;
+}
+
+/**
+ * @brief Establishes an SSL connection to the specified IP address and port using a pre-shared key (PSK) for authentication.
+ *
+ * This function acts as an overloaded variant of the `connect` function, accepting an `IPAddress` object instead of 
+ * a host string. It then delegates the actual connection process to the other variant of the `connect` function.
+ *
+ * @param ip       The IP address of the server to connect to, given as an `IPAddress` object.
+ * @param port     The port number on the server to connect to.
+ * @param pskIdent Pointer to a null-terminated string containing the pre-shared key identity.
+ * @param psKey    Pointer to a null-terminated string containing the pre-shared key.
+ * 
+ * @return Returns 1 if the connection is established successfully, and 0 otherwise.
+ */
+int SSLClient::connect(IPAddress ip, uint16_t port, const char *pskIdent, const char *psKey) {
+  return connect(ip.toString().c_str(), port,_pskIdent, _psKey);
+}
+
+/**
+ * @brief Establishes an SSL connection to the specified host and port using a pre-shared key (PSK) for authentication.
+ *
+ * This function attempts to start an SSL client connection to a server using the provided 
+ * host, port, and pre-shared key details for authentication. If a timeout has been set using 
+ * `_timeout`, it will be used for the handshake timeout.
+ *
+ * @param host     Pointer to a null-terminated string containing the host (domain name or IP) to connect to.
+ * @param port     The port number on the host to connect to.
+ * @param pskIdent Pointer to a null-terminated string containing the pre-shared key identity.
+ * @param psKey    Pointer to a null-terminated string containing the pre-shared key.
+ * 
+ * @return Returns 1 if the connection is established successfully, and 0 otherwise.
+ */
+int SSLClient::connect(const char *host, uint16_t port, const char *pskIdent, const char *psKey) {
+  log_v("start_ssl_client with PSK");
+
+  if(_timeout > 0){
+    sslclient->handshake_timeout = _timeout;
+  }
+
+  int ret = start_ssl_client(sslclient, host, port, _timeout, NULL, NULL, NULL, _pskIdent, _psKey);
+  _lastError = ret;
+
+  if (ret < 0) {
+    log_e("start_ssl_client: %d", ret);
+    stop();
+    return 0;
+  }
+
+  _connected = true;
+  return 1;
+}
+
+/**
+ * @brief Returns the next byte from the SSL connection without consuming it.
+ *
+ * This function allows the caller to inspect the next byte of data 
+ * that would be returned from the `read` function without actually 
+ * consuming or removing that byte from the input stream. If a peeked 
+ * byte is already available, it returns that byte. Otherwise, it 
+ * attempts a timed read and stores the result for future `peek` or 
+ * `read` calls.
+ *
+ * @return The next byte from the SSL connection if available, or -1 if 
+ *         no data is available or there's an error.
+ */
+int SSLClient::peek() {
+  if(_peek >= 0){
+    return _peek;
+  }
+
+  _peek = timedRead();
+  return _peek;
+}
+
+/**
+ * @brief Reads a single byte of data from the SSL connection.
+ *
+ * This function attempts to read one byte of data from the SSL connection. 
+ * If there's an error during the read operation, the function will return 
+ * the error code. Otherwise, it returns the read byte.
+ *
+ * @return The read byte of data from the SSL connection or an error code 
+ *         (negative value) if there's a reading error.
+ */
+int SSLClient::read() {
+  uint8_t data = -1;
+  int res = read(&data, 1);
+
+  if (res < 0) {
+    return res;
+  }
+
+  return data;
+}
+
+/**
+ * @brief Writes a single byte of data to the SSL connection.
+ *
+ * This function sends a single byte of data to the SSL connection 
+ * by internally calling the write function that handles buffer writes.
+ *
+ * @param data The byte of data to be written to the SSL connection.
+ * @return Number of bytes successfully written to the SSL connection. 
+ *         Typically, this will be 1 if the operation was successful, or 
+ *         0 if there was an error or the connection is closed.
+ */
+size_t SSLClient::write(uint8_t data) {
+  return write(&data, 1);
+}
+
+/**
+ * @brief Writes the specified data to the SSL connection.
+ *
+ * This function sends the data in the provided buffer to the established 
+ * SSL connection. If the client is not currently connected, the function 
+ * will return without sending any data.
+ *
+ * @param buf Pointer to the data buffer containing the data to be sent.
+ * @param size Size of the data (in bytes) to be sent.
+ * @return The number of bytes that were successfully sent or `0` if the 
+ * data couldn't be sent or the client was not connected.
+ */
+size_t SSLClient::write(const uint8_t *buf, size_t size) {
+  if (!_connected) {
+    return 0;
+  }
+
+  int res = send_ssl_data(sslclient, buf, size);
+  
+  if (res < 0) {
+    stop();
+    res = 0;
+  }
+  
+  return res;
+}
+
+/**
+ * @brief Reads data from the sslclient.
+ * 
+ * If there is a byte peeked, it returns that byte.
+ * 
+ * @param buf Buffer to read into. 
+ * @param size Size of the buffer.
+ * @return int  1 if a byte has been peeked and the client is not connected.
+ * @return int  < 1 if client is connected and there is an error from get_ssl_receive().
+ * @return int  > 1 if res + peeked. 
  */
 int SSLClient::read(uint8_t *buf, size_t size) {
   log_v("This is the iClient->read() implementation");
@@ -241,13 +426,14 @@ int SSLClient::read(uint8_t *buf, size_t size) {
 }
 
 /**
- * \brief               Returns how many bytes of data are available to be read from the sslclient.
- *                      It takes into account both directly readable bytes and a potentially "peeked" byte.
- *                      If there's an error or the client is not connected, it handles these scenarios appropriately.
+ * @brief Returns how many bytes of data are available to be read from the sslclient.
+ *                      
+ * It takes into account both directly readable bytes and a potentially "peeked" byte.                     
+ * If there's an error or the client is not connected, it handles these scenarios appropriately.
  * 
- * \return int           1 if a byte has been peeked and the client is not connected.
- * \return int          < 1 if client is connected and there is an error from data_to_read().
- * \return int          > 1 if res + peeked.
+ * @return int  1 if a byte has been peeked and the client is not connected.
+ * @return int  < 1 if client is connected and there is an error from data_to_read().
+ * @return int  > 1 if res + peeked.
  */
 int SSLClient::available() {
   int peeked = (_peek >= 0); // 1 if a byte has been peeked (available to read without advancing the read pointer)
@@ -266,62 +452,152 @@ int SSLClient::available() {
   return res+peeked;
 }
 
-uint8_t SSLClient::connected()
-{
-    uint8_t dummy = 0;
-    read(&dummy, 0);
+/**
+ * @brief Checks if the SSLClient is currently connected to a server.
+ *
+ * This function reads zero bytes from the connection to refresh the 
+ * internal connection state. It then returns the current connection status.
+ *
+ * @return A byte indicating the connection status: `1` if connected, `0` otherwise.
+ */
+uint8_t SSLClient::connected() {
+  uint8_t dummy = 0;
+  read(&dummy, 0);
 
-    return _connected;
+  return _connected;
 }
 
-void SSLClient::setCACert (const char *rootCA)
-{
-    log_d("Set root CA");
-    _CA_cert = rootCA;
+/**
+ * @brief Sets the root Certificate Authority (CA) for the SSL/TLS client.
+ *
+ * This function is used to specify the root CA certificate for the SSL/TLS client.
+ * The root CA certificate is crucial for verifying the server's identity during the 
+ * SSL/TLS handshake. If the server's certificate is not signed by this root CA or
+ * is not traceable back to this root CA, the verification will fail.
+ *
+ * @param rootCA The root CA certificate in its binary or PEM form.
+ */
+void SSLClient::setCACert(const char *rootCA) {
+  log_d("Set root CA");
+  _CA_cert = rootCA;
 }
 
-void SSLClient::setCertificate (const char *client_ca)
-{
-    log_d("Set client CA");
-    _cert = client_ca;
+/**
+ * @brief Sets the client certificate for the SSL/TLS client.
+ *
+ * This function is used to provide the client certificate that the SSL/TLS client 
+ * will use during the SSL/TLS handshake. When the server requests a client 
+ * certificate for authentication, the client provides this certificate.
+ *
+ * @param client_ca The client certificate in its binary or PEM form.
+ */
+void SSLClient::setCertificate(const char *client_ca) {
+  log_d("Set client CA");
+  _cert = client_ca;
 }
 
-void SSLClient::setPrivateKey (const char *private_key)
-{
-    log_d("Set client PK");
-    _private_key = private_key;
+/**
+ * @brief Sets the private key for the SSL/TLS client.
+ *
+ * This function is used to provide the private key that the SSL/TLS client will 
+ * use for mutual authentication during the SSL/TLS handshake. In setups requiring
+ * client authentication, the server will challenge the client to prove its identity 
+ * by using this private key.
+ *
+ * @param private_key The private key in its binary or PEM form.
+ */
+void SSLClient::setPrivateKey(const char *private_key) {
+  log_d("Set client PK");
+  _private_key = private_key;
 }
 
+/**
+ * @brief Sets the Pre-Shared Key (PSK) and identifier for SSL/TLS sessions.
+ *
+ * This function configures the Pre-Shared Key and its associated identifier to be
+ * used in the SSL/TLS handshake. PSK is an authentication method where both sides
+ * of the connection (client and server) have a shared secret key, eliminating the 
+ * need for digital certificates.
+ *
+ * @param pskIdent The PSK identifier (usually a string that identifies which key to use).
+ * @param psKey    The Pre-Shared Key in its binary form.
+ */
 void SSLClient::setPreSharedKey(const char *pskIdent, const char *psKey) {
-    log_d("Set PSK");
-    _pskIdent = pskIdent;
-    _psKey = psKey;
+  log_d("Set PSK");
+  _pskIdent = pskIdent;
+  _psKey = psKey;
 }
 
-bool SSLClient::verify(const char* fp, const char* domain_name)
-{
-    if (!sslclient)
-        return false;
+/**
+ * @brief Verifies the SSL/TLS certificate against a specified fingerprint and domain name.
+ *
+ * This function checks the certificate presented by the remote server against a given 
+ * fingerprint and domain name. It ensures that the communication is genuine and not
+ * susceptible to a man-in-the-middle attack.
+ *
+ * @param fp          The expected fingerprint of the remote server's certificate.
+ * @param domain_name The expected domain name or Common Name (CN) of the remote server.
+ *
+ * @return Returns `true` if the fingerprint and domain name of the remote server's certificate
+ * match the provided values, otherwise `false`.
+ */
+bool SSLClient::verify(const char* fp, const char* domain_name) {
+  if (!sslclient) {
+    return false;
+  }
 
-    return verify_ssl_fingerprint(sslclient, fp, domain_name);
+  return verify_ssl_fingerprint(sslclient, fp, domain_name);
 }
 
+/**
+ * @brief Reads data from a provided stream into a dynamically allocated buffer.
+ *
+ * This function attempts to read the specified number of bytes from the given stream into a
+ * buffer. If a previous buffer was allocated by this function, it is freed before new memory is allocated.
+ * If the entire amount of requested data cannot be read from the stream, the allocated buffer is freed.
+ *
+ * @note The function returns a pointer to a statically held character pointer, which means subsequent 
+ * calls to this function will affect the same memory location. It's up to the caller to ensure they don't
+ * overwrite or double-free this memory.
+ *
+ * @param stream The Stream object from which data is to be read.
+ * @param size   The number of bytes to read from the stream.
+ *
+ * @return Returns a pointer to the allocated buffer containing the read data, or nullptr if data could not 
+ * be fully read or memory allocation failed.
+ */
 char *SSLClient::_streamLoad(Stream& stream, size_t size) {
   static char *dest = nullptr;
+
   if(dest) {
-      free(dest);
+    free(dest);
   }
+  
   dest = (char*)malloc(size);
+  
   if (!dest) {
     return nullptr;
   }
+  
   if (size != stream.readBytes(dest, size)) {
     free(dest);
     dest = nullptr;
   }
+  
   return dest;
 }
 
+/**
+ * @brief Loads the Certificate Authority (CA) certificate for the SSL client from a provided stream.
+ *
+ * This function reads the CA certificate data from the given stream and sets it for the 
+ * SSL client. The CA certificate is used by the SSL client to verify the server's certificate.
+ *
+ * @param stream The Stream object from which the CA certificate is read.
+ * @param size   The number of bytes to read from the stream.
+ *
+ * @return Returns true if the CA certificate is successfully loaded and set; otherwise returns false.
+ */
 bool SSLClient::loadCACert(Stream& stream, size_t size) {
   char *dest = _streamLoad(stream, size);
   bool ret = false;
@@ -332,6 +608,17 @@ bool SSLClient::loadCACert(Stream& stream, size_t size) {
   return ret;
 }
 
+/**
+ * @brief Loads a certificate for the SSL client from a provided stream.
+ *
+ * This function reads the certificate data from the given stream and sets it for the 
+ * SSL client. This certificate is used for client-side SSL authentication.
+ *
+ * @param stream The Stream object from which the certificate is read.
+ * @param size   The number of bytes to read from the stream.
+ *
+ * @return Returns true if the certificate is successfully loaded and set; otherwise returns false.
+ */
 bool SSLClient::loadCertificate(Stream& stream, size_t size) {
   char *dest = _streamLoad(stream, size);
   bool ret = false;
@@ -342,6 +629,17 @@ bool SSLClient::loadCertificate(Stream& stream, size_t size) {
   return ret;
 }
 
+/**
+ * @brief Loads a private key for the SSL client from a provided stream.
+ *
+ * This function reads the private key data from the given stream and sets it for the 
+ * SSL client. This key is used for client-side SSL authentication.
+ *
+ * @param stream The Stream object from which the private key is read.
+ * @param size   The number of bytes to read from the stream.
+ *
+ * @return Returns true if the private key is successfully loaded and set; otherwise returns false.
+ */
 bool SSLClient::loadPrivateKey(Stream& stream, size_t size) {
   char *dest = _streamLoad(stream, size);
   bool ret = false;
@@ -352,27 +650,52 @@ bool SSLClient::loadPrivateKey(Stream& stream, size_t size) {
   return ret;
 }
 
-int SSLClient::lastError(char *buf, const size_t size)
-{
-    if (!_lastError) {
-        return 0;
-    }
-    char error_buf[100];
-    mbedtls_strerror(_lastError, error_buf, 100);
-    snprintf(buf, size, "%s", error_buf);
-    return _lastError;
+/**
+ * @brief Retrieves the last SSL error description.
+ *
+ * This function obtains a textual representation of the last SSL error encountered 
+ * and places it into the provided buffer. If there hasn't been an error, 
+ * the function will return 0.
+ *
+ * @param buf   Pointer to the buffer where the error description should be stored.
+ * @param size  Size of the provided buffer.
+ *
+ * @return Returns the last SSL error code. If no error has occurred, returns 0.
+ */
+int SSLClient::lastError(char *buf, const size_t size) {
+  if (!_lastError) {
+    return 0;
+  }
+
+  char error_buf[100];
+  mbedtls_strerror(_lastError, error_buf, 100);
+  snprintf(buf, size, "%s", error_buf);
+  return _lastError;
 }
 
-void SSLClient::setHandshakeTimeout(unsigned long handshake_timeout)
-{
-    sslclient->handshake_timeout = handshake_timeout * 1000;
+/**
+ * @brief Sets the timeout for the SSL handshake.
+ * 
+ * @param handshake_timeout The timeout in seconds.
+ */
+void SSLClient::setHandshakeTimeout(unsigned long handshake_timeout) {
+  sslclient->handshake_timeout = handshake_timeout * 1000;
 }
 
-void SSLClient::setClient(Client* client){
+/**
+ * @brief Sets the client for the SSLClient object.
+ * 
+ * @param client A pointer to the client class object. 
+ */
+void SSLClient::setClient(Client* client) {
     sslclient->client = client;
 }
 
-void SSLClient::setTimeout(uint32_t milliseconds){ 
+/**
+ * @brief Sets the timeout for the SSLClient object.
+ * 
+ * @param milliseconds The timeout in milliseconds.
+ */
+void SSLClient::setTimeout(uint32_t milliseconds) { 
   _timeout = milliseconds; 
 }
-

--- a/src/ssl_client.cpp
+++ b/src/ssl_client.cpp
@@ -32,17 +32,23 @@ const char *pers = "esp32-tls";
  * \return int      The error code. 
  */
 static int _handle_error(int err, const char * function, int line) {
-    if(err == -30848){
-        return err;
-    }
-#ifdef MBEDTLS_ERROR_C
-    char error_buf[100];
-    mbedtls_strerror(err, error_buf, 100);
-    log_e("[%s():%d]: (%d) %s", function, line, err, error_buf);
-#else
-    log_e("[%s():%d]: code %d", function, line, err);
-#endif
+  if(err == -30848) {
     return err;
+  }
+#ifdef MBEDTLS_ERROR_C
+  char error_buf[100];
+  mbedtls_strerror(err, error_buf, 100);
+
+  if (err == MBEDTLS_ERR_NET_SEND_FAILED) { 
+    strncpy(error_buf, "Failed to send data - underlying network layer error", sizeof(error_buf) - 1);
+    error_buf[sizeof(error_buf) - 1] = '\0';
+  }
+  
+  log_e("[%s():%d]: (%d) %s", function, line, err, error_buf);
+#else
+  log_e("[%s():%d]: code %d", function, line, err);
+#endif
+  return err;
 }
 
 #define handle_error(e) _handle_error(e, __FUNCTION__, __LINE__)
@@ -58,6 +64,8 @@ static int _handle_error(int err, const char * function, int line) {
  * \return         the number of bytes received,
  *                 or a non-zero error code; with a non-blocking socket,
  *                 MBEDTLS_ERR_SSL_WANT_READ indicates read() would block.
+ * \return int    -1 if Client* is nullptr.
+ * \return int    -2 if connect failed.
  */
 static int client_net_recv( void *ctx, unsigned char *buf, size_t len ) {
   Client *client = (Client*)ctx;
@@ -67,8 +75,8 @@ static int client_net_recv( void *ctx, unsigned char *buf, size_t len ) {
   }
   
   if (!client->connected()) {
-     log_e("Not connected!");
-     return -2;
+    log_e("Not connected!");
+    return -2;
   }
 
   int result = client->read(buf, len);
@@ -92,6 +100,8 @@ static int client_net_recv( void *ctx, unsigned char *buf, size_t len ) {
  * \return int      The number of bytes received, or a non-zero error code;
  *                  with a non-blocking socket, MBEDTLS_ERR_SSL_WANT_READ
  *                  indicates read() would block. 
+ * \return int    -1 if Client* is nullptr.
+ * \return int    -2 if connect failed.
  */
 int client_net_recv_timeout(void *ctx, unsigned char *buf, size_t len, uint32_t timeout) {
   Client *client = (Client*)ctx;
@@ -135,9 +145,11 @@ int client_net_recv_timeout(void *ctx, unsigned char *buf, size_t len, uint32_t 
  * \param ctx     Client*
  * \param buf     The buffer to read from
  * \param len     The length of the buffer
- * \return        The number of bytes sent, or a non-zero
+ * \return int    The number of bytes sent, or a non-zero
  *                error code; with a non-blocking socket,
  *                MBEDTLS_ERR_SSL_WANT_WRITE indicates write() would block.
+ * \return int    -1 if Client* is nullptr.
+ * \return int    -2 if connect failed.
  */
 static int client_net_send( void *ctx, const unsigned char *buf, size_t len ) {
   Client *client = (Client*)ctx;
@@ -186,8 +198,7 @@ static int client_net_send( void *ctx, const unsigned char *buf, size_t len ) {
  * \param ssl_client  sslclient_context* - The ssl client context. 
  * \param client      Client* - The client. 
  */
-void ssl_init(sslclient_context *ssl_client, Client *client)
-{
+void ssl_init(sslclient_context *ssl_client, Client *client) {
   log_v("Init SSL");
   // reset embedded pointers to zero
   memset(ssl_client, 0, sizeof(sslclient_context));
@@ -209,186 +220,265 @@ void ssl_init(sslclient_context *ssl_client, Client *client)
  * \param cli_key     const char*- The client key.
  * \param pskIdent    const char* - The PSK identity.
  * \param psKey       const char* - The PSK key.
- * \return int        1 if successful. 
+ * \return int        1 if successful.
+ * \return int        -1 if Client* is nullptr.
+ * \return int        -2 if connect failed.
+ * \return int        -3 if PSK key is invalid.
+ * \return int        -4 if SSL handshake timeout.
  */
-int start_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t port, int timeout, const char *rootCABuff, const char *cli_cert, const char *cli_key, const char *pskIdent, const char *psKey)
-{
-  char buf[512];
-  int ret, flags;
-  //int enable = 1;
+int start_ssl_client(
+  sslclient_context *ssl_client,
+  const char *host,
+  uint32_t port,
+  int timeout,
+  const char *rootCABuff,
+  const char *cli_cert,
+  const char *cli_key,
+  const char *pskIdent,
+  const char *psKey
+) {
   log_v("Free internal heap before TLS %u", ESP.getFreeHeap());
+  log_v("Connecting to %s:%d", host, port);
 
-  log_d("Connecting to %s:%d", host, port);
+  int ret = 0; // for mbedtls function return values
+  int func_ret = 0; // for start_ssl_client return values
+  bool ca_cert_initialized = false;
+  bool client_cert_initialized = false;
+  bool client_key_initialized = false;
+  bool breakBothLoops = false;
 
-  Client *pClient = ssl_client->client;
+  do { // executes once, breaks on error...
 
-  if (!pClient) {
-    log_e("Client provider not initialised");
-    return -1;
-  }
-
-  if (!pClient->connect(host, port)) {
-    log_e("Connect to Server failed!");
-    return -2;
-  }
-
-  log_v("Seeding the random number generator");
-  mbedtls_entropy_init(&ssl_client->entropy_ctx);
-
-  ret = mbedtls_ctr_drbg_seed(&ssl_client->drbg_ctx, mbedtls_entropy_func,
-                              &ssl_client->entropy_ctx, (const unsigned char *) pers, strlen(pers));
-  if (ret < 0) {
-    return handle_error(ret);
-  }
-
-  log_v("Setting up the SSL/TLS structure...");
-
-  if ((ret = mbedtls_ssl_config_defaults(&ssl_client->ssl_conf,
-                                          MBEDTLS_SSL_IS_CLIENT,
-                                          MBEDTLS_SSL_TRANSPORT_STREAM,
-                                          MBEDTLS_SSL_PRESET_DEFAULT)) != 0) {
-    return handle_error(ret);
-  }
-
-  // MBEDTLS_SSL_VERIFY_REQUIRED if a CA certificate is defined on Arduino IDE and
-  // MBEDTLS_SSL_VERIFY_NONE if not.
-
-  if (rootCABuff != NULL) {
-    log_v("Loading CA cert");
-    mbedtls_x509_crt_init(&ssl_client->ca_cert);
-    mbedtls_ssl_conf_authmode(&ssl_client->ssl_conf, MBEDTLS_SSL_VERIFY_REQUIRED);
-    ret = mbedtls_x509_crt_parse(&ssl_client->ca_cert, (const unsigned char *)rootCABuff, strlen(rootCABuff) + 1);
-    mbedtls_ssl_conf_ca_chain(&ssl_client->ssl_conf, &ssl_client->ca_cert, NULL);
-    //mbedtls_ssl_conf_verify(&ssl_client->ssl_ctx, my_verify, NULL );
-    if (ret < 0) {
-      return handle_error(ret);
-    }
-  } else if (pskIdent != NULL && psKey != NULL) {
-    log_v("Setting up PSK");
-    // convert PSK from hex to binary
-    if ((strlen(psKey) & 1) != 0 || strlen(psKey) > 2*MBEDTLS_PSK_MAX_LEN) {
-      log_e("pre-shared key not valid hex or too long");
-      return -1;
-    }
-    unsigned char psk[MBEDTLS_PSK_MAX_LEN];
-    size_t psk_len = strlen(psKey)/2;
-    for (int j=0; j<strlen(psKey); j+= 2) {
-      char c = psKey[j];
-      if (c >= '0' && c <= '9') c -= '0';
-      else if (c >= 'A' && c <= 'F') c -= 'A' - 10;
-      else if (c >= 'a' && c <= 'f') c -= 'a' - 10;
-      else return -1;
-      psk[j/2] = c<<4;
-      c = psKey[j+1];
-      if (c >= '0' && c <= '9') c -= '0';
-      else if (c >= 'A' && c <= 'F') c -= 'A' - 10;
-      else if (c >= 'a' && c <= 'f') c -= 'a' - 10;
-      else return -1;
-      psk[j/2] |= c;
-    }
-    // set mbedtls config
-    ret = mbedtls_ssl_conf_psk(&ssl_client->ssl_conf, psk, psk_len,
-                               (const unsigned char *)pskIdent, strlen(pskIdent));
-    if (ret != 0) {
-      log_e("mbedtls_ssl_conf_psk returned %d", ret);
-      return handle_error(ret);
-    }
-  } else {
-    mbedtls_ssl_conf_authmode(&ssl_client->ssl_conf, MBEDTLS_SSL_VERIFY_NONE);
-    log_i("WARNING: Use certificates for a more secure communication!");
-  }
-
-  if (cli_cert != NULL && cli_key != NULL) {
-    mbedtls_x509_crt_init(&ssl_client->client_cert);
-    mbedtls_pk_init(&ssl_client->client_key);
-
-    log_v("Loading CRT cert");
-
-    ret = mbedtls_x509_crt_parse(&ssl_client->client_cert, (const unsigned char *)cli_cert, strlen(cli_cert) + 1);
-    if (ret < 0) {
-      return handle_error(ret);
+    // Step 1 - Initiate TCP connection
+    Client *pClient = ssl_client->client;
+    if (!pClient) {
+      log_e("Client pointer is null.");
+      func_ret = -1;
+      break;
     }
 
-    log_v("Loading private key");
-    ret = mbedtls_pk_parse_key(&ssl_client->client_key, (const unsigned char *)cli_key, strlen(cli_key) + 1, NULL, 0);
+    log_v("Client pointer: %p", (void*) pClient); // log_v
 
-    if (ret != 0) {
-      mbedtls_x509_crt_free(&ssl_client->client_cert); // cert+key are free'd in pair
-      return handle_error(ret);
+    if (!pClient->connect(host, port)) {
+      log_e("Connection to server failed!");
+      func_ret = -2;
+      break;
     }
 
-    mbedtls_ssl_conf_own_cert(&ssl_client->ssl_conf, &ssl_client->client_cert, &ssl_client->client_key);
-  }
+    // Step 2 - Seed the random number generator
+    log_v("Seeding the random number generator");
+    mbedtls_entropy_init(&ssl_client->entropy_ctx);
+    log_v("Entropy context initialized"); // log_v
 
-  log_v("Setting hostname for TLS session...");
+    ret = mbedtls_ctr_drbg_seed(&ssl_client->drbg_ctx, mbedtls_entropy_func,
+                                &ssl_client->entropy_ctx, (const unsigned char *) pers, strlen(pers));
 
-  // Hostname set here should match CN in server certificate
-  if ((ret = mbedtls_ssl_set_hostname(&ssl_client->ssl_ctx, host)) != 0) {
-    return handle_error(ret);
-  }
-
-  mbedtls_ssl_conf_rng(&ssl_client->ssl_conf, mbedtls_ctr_drbg_random, &ssl_client->drbg_ctx);
-
-  if ((ret = mbedtls_ssl_setup(&ssl_client->ssl_ctx, &ssl_client->ssl_conf)) != 0) {
-    return handle_error(ret);
-  }
-
-  log_v("Setting up IO callbacks...");
-  mbedtls_ssl_set_bio(&ssl_client->ssl_ctx, ssl_client->client,
-                      client_net_send, NULL, client_net_recv_timeout );
-  
-  log_v("Setting timeout...");
-  mbedtls_ssl_conf_read_timeout(&ssl_client->ssl_conf,  timeout);
-
-  log_v("Performing the SSL/TLS handshake...");
-  unsigned long handshake_start_time=millis();
-  while ((ret = mbedtls_ssl_handshake(&ssl_client->ssl_ctx)) != 0) {
-    if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
-      return handle_error(ret);
+    if (ret == MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED || ret != 0) {
+      break;
     }
-    if((millis()-handshake_start_time)>ssl_client->handshake_timeout) {
-      return -1;
-    }
-    vTaskDelay(10 / portTICK_PERIOD_MS);
-  }
 
-  if (cli_cert != NULL && cli_key != NULL) {
-    log_d("Protocol is %s Ciphersuite is %s", mbedtls_ssl_get_version(&ssl_client->ssl_ctx), mbedtls_ssl_get_ciphersuite(&ssl_client->ssl_ctx));
-    if ((ret = mbedtls_ssl_get_record_expansion(&ssl_client->ssl_ctx)) >= 0) {
-      log_d("Record expansion is %d", ret);
+    log_v("Random number generator seeded, ret: %d", ret); // log_v
+
+    // Step 3 - Set up the SSL/TLS defaults
+    log_v("Setting up the SSL/TLS defaults...");
+
+    ret = mbedtls_ssl_config_defaults(&ssl_client->ssl_conf,
+                                      MBEDTLS_SSL_IS_CLIENT,
+                                      MBEDTLS_SSL_TRANSPORT_STREAM,
+                                      MBEDTLS_SSL_PRESET_DEFAULT);
+    if (ret != 0) { // MBEDTLS_ERR_XXX_ALLOC_FAILED undefined?
+      break;
+    }
+
+    log_v("SSL config defaults set, ret: %d", ret);
+
+    // Step 4 route a - Set up required auth mode rootCaBuff
+    if (rootCABuff != NULL) {
+      log_v("Loading CA cert");
+      mbedtls_x509_crt_init(&ssl_client->ca_cert);
+      mbedtls_ssl_conf_authmode(&ssl_client->ssl_conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+      ret = mbedtls_x509_crt_parse(&ssl_client->ca_cert, (const unsigned char *)rootCABuff, strlen(rootCABuff) + 1);
+
+      if (ret < 0) {
+        break; // if ret > 0 n certs failed, ret < 0 pem or x509 error code.
+      }
+
+      mbedtls_ssl_conf_ca_chain(&ssl_client->ssl_conf, &ssl_client->ca_cert, NULL);
+      // mbedtls_ssl_conf_verify(&ssl_client->ssl_ctx, my_verify, NULL );
+
+      ca_cert_initialized = true;
+      
+    } else if (pskIdent != NULL && psKey != NULL) {
+      log_v("Setting up PSK");
+      
+      // convert PSK from hex to binary
+      if ((strlen(psKey) & 1) != 0 || strlen(psKey) > 2*MBEDTLS_PSK_MAX_LEN) {
+        log_e("pre-shared key not valid hex or too long");
+        func_ret = -3;
+        break;
+      }
+
+      unsigned char psk[MBEDTLS_PSK_MAX_LEN];
+      size_t psk_len = strlen(psKey)/2;
+
+      for (int j=0; j<strlen(psKey); j+= 2) {
+        char c = psKey[j];
+        if (c >= '0' && c <= '9') c -= '0';
+        else if (c >= 'A' && c <= 'F') c -= 'A' - 10;
+        else if (c >= 'a' && c <= 'f') c -= 'a' - 10;
+        else return -1;
+        psk[j/2] = c<<4;
+        c = psKey[j+1];
+        if (c >= '0' && c <= '9') c -= '0';
+        else if (c >= 'A' && c <= 'F') c -= 'A' - 10;
+        else if (c >= 'a' && c <= 'f') c -= 'a' - 10;
+        else return -1;
+        psk[j/2] |= c;
+      }
+
+      // set mbedtls config
+      ret = mbedtls_ssl_conf_psk(&ssl_client->ssl_conf, psk, psk_len,
+                                (const unsigned char *)pskIdent, strlen(pskIdent));
+      if (ret != 0) { // MBEDTLS_ERR_SSL_XXX undefined?
+        log_e("mbedtls_ssl_conf_psk returned %d", ret);
+        break;
+      }
     } else {
-      log_w("Record expansion is unknown (compression)");
+      mbedtls_ssl_conf_authmode(&ssl_client->ssl_conf, MBEDTLS_SSL_VERIFY_NONE);
+      log_i("WARNING: Use certificates for a more secure communication!");
     }
-  }
 
-  log_v("Verifying peer X.509 certificate...");
+    // Step 4 route b - Set up required auth mode cli_cert and cli_key
+    if (cli_cert != NULL && cli_key != NULL) {
+      mbedtls_x509_crt_init(&ssl_client->client_cert);
+      mbedtls_pk_init(&ssl_client->client_key);
 
-  if ((flags = mbedtls_ssl_get_verify_result(&ssl_client->ssl_ctx)) != 0) {
-    memset(buf, 0, sizeof(buf));
-    mbedtls_x509_crt_verify_info(buf, sizeof(buf), "  ! ", flags);
-    log_e("Failed to verify peer certificate! verification info: %s", buf);
-    stop_ssl_socket(ssl_client, rootCABuff, cli_cert, cli_key);  //It's not safe continue.
-    return handle_error(ret);
-  } else {
-    log_v("Certificate verified.");
-  }
+      log_v("Loading CRT cert");
+      ret = mbedtls_x509_crt_parse(&ssl_client->client_cert, (const unsigned char *)cli_cert, strlen(cli_cert) + 1);
+      if (ret != 0) {
+        break; // if ret > 0 n certs failed, ret < 0 pem or x509 error code.
+      } else {
+        client_cert_initialized = true;
+      }
+
+      log_v("Loading private key");
+      ret = mbedtls_pk_parse_key(&ssl_client->client_key, (const unsigned char *)cli_key, strlen(cli_key) + 1, NULL, 0);
+      if (ret != 0) { // PK or PEM non-zero error codes
+        mbedtls_x509_crt_free(&ssl_client->client_cert); // cert+key are free'd in pair
+        break;
+      } else {
+        client_key_initialized = true;
+      }
+
+      ret = mbedtls_ssl_conf_own_cert(&ssl_client->ssl_conf, &ssl_client->client_cert, &ssl_client->client_key);
+      if (ret == MBEDTLS_ERR_SSL_ALLOC_FAILED || ret != 0) {
+        break;
+      }
+    }
+
+    // Step 5 - Set hostname for TLS session
+    log_v("Setting hostname for TLS session...");
+
+    // Hostname set here should match CN in server certificate
+    ret = mbedtls_ssl_set_hostname(&ssl_client->ssl_ctx, host);
+     
+    if (ret == MBEDTLS_ERR_SSL_ALLOC_FAILED || ret == MBEDTLS_ERR_SSL_BAD_INPUT_DATA || ret != 0) {
+      break;
+    }
+
+    mbedtls_ssl_conf_rng(&ssl_client->ssl_conf, mbedtls_ctr_drbg_random, &ssl_client->drbg_ctx);
+
+    ret = mbedtls_ssl_setup(&ssl_client->ssl_ctx, &ssl_client->ssl_conf);
+
+    if (ret == MBEDTLS_ERR_SSL_ALLOC_FAILED || ret != 0) {
+      break;
+    }
+
+    // Step 6 - Set up the I/O callbacks (this is the heart of it)
+    log_v("Setting up IO callbacks...");
+    mbedtls_ssl_set_bio(&ssl_client->ssl_ctx, ssl_client->client,
+                        client_net_send, NULL, client_net_recv_timeout );
   
-  if (rootCABuff != NULL) {
+    log_v("Setting timeout to %i", timeout);
+    mbedtls_ssl_conf_read_timeout(&ssl_client->ssl_conf,  timeout);
+
+    // Step 7 - Perform the SSL/TLS handshake
+    log_v("Performing the SSL/TLS handshake...");
+    unsigned long handshake_start_time = millis();
+
+    while ((ret = mbedtls_ssl_handshake(&ssl_client->ssl_ctx)) != 0) {
+      if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+        break;
+      }
+      if ((millis()-handshake_start_time) > ssl_client->handshake_timeout) {
+        log_e("SSL handshake timeout");
+        func_ret = -4;
+        breakBothLoops = true;
+        break; 
+      }
+      vTaskDelay(10 / portTICK_PERIOD_MS);
+    }
+
+    if (breakBothLoops) {
+      break;  // break the outer do-while loop
+    }
+
+    if (cli_cert != NULL && cli_key != NULL) {
+      log_v("Protocol is %s Ciphersuite is %s", mbedtls_ssl_get_version(&ssl_client->ssl_ctx), mbedtls_ssl_get_ciphersuite(&ssl_client->ssl_ctx));
+      ret = mbedtls_ssl_get_record_expansion(&ssl_client->ssl_ctx);
+      if (ret != 0) {
+        if (ret == MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE) {
+          log_w("Record expansion is not available (compression)");
+        } else {
+          log_e(" mbedtls_ssl_get_record_expansion returned -0x%x", -ret);
+        }
+        break;
+      } else {
+        log_w("Record expansion is unknown (compression)");
+      }
+    }
+
+    // Step 8 - Verify the server certificate
+    log_v("Verifying peer X.509 certificate...");
+
+    int flags = mbedtls_ssl_get_verify_result(&ssl_client->ssl_ctx);
+
+    if (ret != 0) {
+      char buf[512];
+      memset(buf, 0, sizeof(buf));
+      mbedtls_x509_crt_verify_info(buf, sizeof(buf), "  ! ", flags);
+      log_e("Failed to verify peer certificate! verification info: %s", buf);
+      stop_ssl_socket(ssl_client, rootCABuff, cli_cert, cli_key);  // It's not safe continue.
+      break;
+    } else {
+      log_v("Certificate verified.");
+    }
+
+  } while (0); // executes once, breaks on error...
+
+  // Step 9 - Cleanup and return
+  if (ca_cert_initialized) {
     mbedtls_x509_crt_free(&ssl_client->ca_cert);
   }
 
-  if (cli_cert != NULL) {
+  if (client_cert_initialized) {
     mbedtls_x509_crt_free(&ssl_client->client_cert);
   }
 
-  if (cli_key != NULL) {
+  if (client_key_initialized) {
     mbedtls_pk_free(&ssl_client->client_key);
-  }    
+  }
 
   log_v("Free internal heap after TLS %u", ESP.getFreeHeap());
 
-  //return ssl_client->socket;
-  return 1;
+  if (ret < 0) {
+    return handle_error(ret);
+    stop_ssl_socket(ssl_client, rootCABuff, cli_cert, cli_key);
+  } else {
+    func_ret = 1;
+  }
+
+  return func_ret;
 }
 
 /**
@@ -401,26 +491,44 @@ int start_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t p
  */
 void stop_ssl_socket(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key) {
   log_v("Cleaning SSL connection.");
-
+  log_v("Stopping SSL client. Current client pointer address: %p", (void *)ssl_client->client);
+  
+  // Stop the client connection
   ssl_client->client->stop();
 
-  // avoid memory leak if ssl connection attempt failed
   if (ssl_client->ssl_conf.ca_chain != NULL) {
+    log_v("Freeing CA cert. Current ca_cert address: %p", (void *)&ssl_client->ca_cert);
+
+    // Free the memory associated with the CA certificate
     mbedtls_x509_crt_free(&ssl_client->ca_cert);
   }
+
   if (ssl_client->ssl_conf.key_cert != NULL) {
+    log_v("Freeing client cert and client key. Current client_cert address: %p, client_key address: %p", 
+          (void *)&ssl_client->client_cert, (void *)&ssl_client->client_key);
+
+    // Free the memory associated with the client certificate and key
     mbedtls_x509_crt_free(&ssl_client->client_cert);
     mbedtls_pk_free(&ssl_client->client_key);
   }
 
+  // Free other SSL-related contexts and log their current addresses
+  log_v("Freeing SSL context. Current ssl_ctx address: %p", (void *)&ssl_client->ssl_ctx);
   mbedtls_ssl_free(&ssl_client->ssl_ctx);
+
+  log_v("Freeing SSL config. Current ssl_conf address: %p", (void *)&ssl_client->ssl_conf);
   mbedtls_ssl_config_free(&ssl_client->ssl_conf);
+
+  log_v("Freeing DRBG context. Current drbg_ctx address: %p", (void *)&ssl_client->drbg_ctx);
   mbedtls_ctr_drbg_free(&ssl_client->drbg_ctx);
+
+  log_v("Freeing entropy context. Current entropy_ctx address: %p", (void *)&ssl_client->entropy_ctx);
   mbedtls_entropy_free(&ssl_client->entropy_ctx);
 
-  // reset embedded pointers to zero
-  memset(ssl_client, 0, sizeof(sslclient_context));
+  // log_v("Resetting embedded pointers to zero for ssl_client at address: %p", (void *)ssl_client);
+  // memset(ssl_client, 0, sizeof(sslclient_context));
 }
+
 
 /**
  * \brief             Check if there is data to read or not.
@@ -450,7 +558,16 @@ int data_to_read(sslclient_context *ssl_client) {
   * \return int         The number of bytes sent. 
   */
 int send_ssl_data(sslclient_context *ssl_client, const uint8_t *data, size_t len) {
-  log_v("Writing SSL (%zu bytes)...", len);  //for low level debug
+    // Log contents of ssl_client
+  if(ssl_client != nullptr) {
+    log_v("ssl_client->client: %p", (void *)ssl_client->client);
+    log_v("ssl_client->handshake_timeout: %lu", ssl_client->handshake_timeout);
+  } else {
+    log_e("ssl_client is null!");
+    return -1;
+  }
+  
+  log_v("Writing SSL (%zu bytes)...", len); // for low level debug
   int ret = -1;
 
   while ((ret = mbedtls_ssl_write(&ssl_client->ssl_ctx, data, len)) <= 0) {
@@ -460,7 +577,7 @@ int send_ssl_data(sslclient_context *ssl_client, const uint8_t *data, size_t len
   }
 
   len = ret;
-  log_v("%zu bytes written", len);  //for low level debug
+  log_v("%zu bytes written", len); // for low level debug
   return ret;
 }
 

--- a/src/ssl_client.h
+++ b/src/ssl_client.h
@@ -40,18 +40,6 @@ typedef struct sslclient_context {
   unsigned long handshake_timeout;
 } sslclient_context;
 
-static int configure_default_ssl(sslclient_context *ssl_client);
-static int configure_ca_cert(sslclient_context *ssl_client, const char *rootCABuff);
-static int configure_psk(sslclient_context *ssl_client, const char *pskIdent, const char *psKey);
-static int configure_client_cert_key(sslclient_context *ssl_client, const char *cli_cert, const char *cli_key);
-int initialize_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t port);
-int seed_rng(sslclient_context *ssl_client);
-int setup_ssl_configuration(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key, const char *pskIdent, const char *psKey);
-int load_certificates_and_keys(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key);
-int perform_handshake(sslclient_context *ssl_client, const char *host, int timeout=SSL_CLIENT_SLOW_NETWORK_HANDSHAKE_TIMEOUT);
-void confirm_protocols(sslclient_context* ssl_client, const char* cli_cert, const char* cli_key);
-int verify_peer_certificate(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key);
-void clean_up_resources(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key);
 void ssl_init(sslclient_context *ssl_client, Client *client);
 int start_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t port, int timeout, const char *rootCABuff, const char *cli_cert, const char *cli_key, const char *pskIdent, const char *psKey);
 void stop_ssl_socket(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key);


### PR DESCRIPTION
- refactor of start_ssl_client to allow clearer exit codes for errors and fast fail
- remove memset / bzero call stop_ssl_client and this created a nullptr

closes #49 