### PR TITLE
fix: get record expansion bug

### DIFF
--- a/src/SSLClient.cpp
+++ b/src/SSLClient.cpp
@@ -525,7 +525,6 @@ void SSLClient::setCACertBundle(const uint8_t * bundle) {
   if (bundle != NULL) {
     ssl_lib_crt_bundle_set(bundle);
     _use_ca_bundle = true;
-    _use_insecure = false;
   } else {
     ssl_lib_crt_bundle_detach(NULL);
     _use_ca_bundle = false;

--- a/src/certBundle.c
+++ b/src/certBundle.c
@@ -26,9 +26,9 @@ static mbedtls_x509_crt s_dummy_crt;
 
 
 typedef struct crt_bundle_t {
-    const uint8_t **crts;
-    uint16_t num_certs;
-    size_t x509_crt_bundle_len;
+  const uint8_t **crts;
+  uint16_t num_certs;
+  size_t x509_crt_bundle_len;
 } crt_bundle_t;
 
 static crt_bundle_t s_crt_bundle;
@@ -39,43 +39,41 @@ static int esp_crt_check_signature(mbedtls_x509_crt *child, const uint8_t *pub_k
 
 static int esp_crt_check_signature(mbedtls_x509_crt *child, const uint8_t *pub_key_buf, size_t pub_key_len)
 {
-    int ret = 0;
-    mbedtls_x509_crt parent;
-    const mbedtls_md_info_t *md_info;
-    unsigned char hash[MBEDTLS_MD_MAX_SIZE];
+  int ret = 0;
+  mbedtls_x509_crt parent;
+  const mbedtls_md_info_t *md_info;
+  unsigned char hash[MBEDTLS_MD_MAX_SIZE];
 
-    mbedtls_x509_crt_init(&parent);
+  mbedtls_x509_crt_init(&parent);
 
-    if ( (ret = mbedtls_pk_parse_public_key(&parent.pk, pub_key_buf, pub_key_len) ) != 0) {
-        log_e("PK parse failed with error %X", ret);
-        goto cleanup;
-    }
+  if ( (ret = mbedtls_pk_parse_public_key(&parent.pk, pub_key_buf, pub_key_len) ) != 0) {
+    log_e("PK parse failed with error %X", ret);
+    goto cleanup;
+  }
 
 
-    // Fast check to avoid expensive computations when not necessary
-    if (!mbedtls_pk_can_do(&parent.pk, child->sig_pk)) {
-        log_e("Simple compare failed");
-        ret = -1;
-        goto cleanup;
-    }
+  // Fast check to avoid expensive computations when not necessary
+  if (!mbedtls_pk_can_do(&parent.pk, child->sig_pk)) {
+    log_e("Simple compare failed");
+    ret = -1;
+    goto cleanup;
+  }
 
-    md_info = mbedtls_md_info_from_type(child->sig_md);
-    if ( (ret = mbedtls_md( md_info, child->tbs.p, child->tbs.len, hash )) != 0 ) {
-        log_e("Internal mbedTLS error %X", ret);
-        goto cleanup;
-    }
+  md_info = mbedtls_md_info_from_type(child->sig_md);
+  if ( (ret = mbedtls_md( md_info, child->tbs.p, child->tbs.len, hash )) != 0 ) {
+    log_e("Internal mbedTLS error %X", ret);
+    goto cleanup;
+  }
 
-    if ( (ret = mbedtls_pk_verify_ext( child->sig_pk, child->sig_opts, &parent.pk,
-                                       child->sig_md, hash, mbedtls_md_get_size( md_info ),
-                                       child->sig.p, child->sig.len )) != 0 ) {
-
-        log_e("PK verify failed with error %X", ret);
-        goto cleanup;
-    }
+  if ((ret = mbedtls_pk_verify_ext(child->sig_pk, child->sig_opts, &parent.pk, child->sig_md, hash, mbedtls_md_get_size( md_info ),
+                                   child->sig.p, child->sig.len )) != 0 ) {
+      log_e("PK verify failed with error %X", ret);
+      goto cleanup;
+  }
 cleanup:
-    mbedtls_x509_crt_free(&parent);
+  mbedtls_x509_crt_free(&parent);
 
-    return ret;
+  return ret;
 }
 
 
@@ -85,130 +83,125 @@ cleanup:
  * only verify the first untrusted link in the chain is signed by the
  * root certificate in the trusted bundle
 */
-int esp_crt_verify_callback(void *buf, mbedtls_x509_crt *crt, int depth, uint32_t *flags)
-{
-    mbedtls_x509_crt *child = crt;
+int esp_crt_verify_callback(void *buf, mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
+  mbedtls_x509_crt *child = crt;
 
-    /* It's OK for a trusted cert to have a weak signature hash alg.
-       as we already trust this certificate */
-    uint32_t flags_filtered = *flags & ~(MBEDTLS_X509_BADCERT_BAD_MD);
+  /* It's OK for a trusted cert to have a weak signature hash alg.
+      as we already trust this certificate */
+  uint32_t flags_filtered = *flags & ~(MBEDTLS_X509_BADCERT_BAD_MD);
 
-    if (flags_filtered != MBEDTLS_X509_BADCERT_NOT_TRUSTED) {
-        return 0;
-    }
+  if (flags_filtered != MBEDTLS_X509_BADCERT_NOT_TRUSTED) {
+    return 0;
+  }
 
 
-    if (s_crt_bundle.crts == NULL) {
-        log_e("No certificates in bundle");
-        return MBEDTLS_ERR_X509_FATAL_ERROR;
-    }
-
-    log_d("%d certificates in bundle", s_crt_bundle.num_certs);
-
-    size_t name_len = 0;
-    const uint8_t *crt_name;
-
-    bool crt_found = false;
-    int start = 0;
-    int end = s_crt_bundle.num_certs - 1;
-    int middle = (end - start) / 2;
-
-    /* Look for the certificate using binary search on subject name */
-    while (start <= end) {
-        name_len = s_crt_bundle.crts[middle][0] << 8 | s_crt_bundle.crts[middle][1];
-        crt_name = s_crt_bundle.crts[middle] + CRT_HEADER_OFFSET;
-
-        int cmp_res = memcmp(child->issuer_raw.p, crt_name, name_len );
-        if (cmp_res == 0) {
-            crt_found = true;
-            break;
-        } else if (cmp_res < 0) {
-            end = middle - 1;
-        } else {
-            start = middle + 1;
-        }
-        middle = (start + end) / 2;
-    }
-
-    int ret = MBEDTLS_ERR_X509_FATAL_ERROR;
-    if (crt_found) {
-        size_t key_len = s_crt_bundle.crts[middle][2] << 8 | s_crt_bundle.crts[middle][3];
-        ret = esp_crt_check_signature(child, s_crt_bundle.crts[middle] + CRT_HEADER_OFFSET + name_len, key_len);
-    }
-
-    if (ret == 0) {
-        log_i("Certificate validated");
-        *flags = 0;
-        return 0;
-    }
-
-    log_e("Failed to verify certificate");
+  if (s_crt_bundle.crts == NULL) {
+    log_e("No certificates in bundle");
     return MBEDTLS_ERR_X509_FATAL_ERROR;
+  }
+
+  log_d("%d certificates in bundle", s_crt_bundle.num_certs);
+
+  size_t name_len = 0;
+  const uint8_t *crt_name;
+
+  bool crt_found = false;
+  int start = 0;
+  int end = s_crt_bundle.num_certs - 1;
+  int middle = (end - start) / 2;
+
+  /* Look for the certificate using binary search on subject name */
+  while (start <= end) {
+    name_len = s_crt_bundle.crts[middle][0] << 8 | s_crt_bundle.crts[middle][1];
+    crt_name = s_crt_bundle.crts[middle] + CRT_HEADER_OFFSET;
+
+    int cmp_res = memcmp(child->issuer_raw.p, crt_name, name_len );
+    if (cmp_res == 0) {
+      crt_found = true;
+      break;
+    } else if (cmp_res < 0) {
+      end = middle - 1;
+    } else {
+      start = middle + 1;
+    }
+    middle = (start + end) / 2;
+  }
+
+  int ret = MBEDTLS_ERR_X509_FATAL_ERROR;
+  if (crt_found) {
+    size_t key_len = s_crt_bundle.crts[middle][2] << 8 | s_crt_bundle.crts[middle][3];
+    ret = esp_crt_check_signature(child, s_crt_bundle.crts[middle] + CRT_HEADER_OFFSET + name_len, key_len);
+  }
+
+  if (ret == 0) {
+    log_i("Certificate validated");
+    *flags = 0;
+    return 0;
+  }
+
+  log_e("Failed to verify certificate");
+  return MBEDTLS_ERR_X509_FATAL_ERROR;
 }
 
 
 /* Initialize the bundle into an array so we can do binary search for certs,
    the bundle generated by the python utility is already presorted by subject name
  */
-static esp_err_t esp_crt_bundle_init(const uint8_t *x509_bundle)
-{
-    s_crt_bundle.num_certs = (x509_bundle[0] << 8) | x509_bundle[1];
-    s_crt_bundle.crts = calloc(s_crt_bundle.num_certs, sizeof(x509_bundle));
+static esp_err_t esp_crt_bundle_init(const uint8_t *x509_bundle) {
+  s_crt_bundle.num_certs = (x509_bundle[0] << 8) | x509_bundle[1];
+  s_crt_bundle.crts = calloc(s_crt_bundle.num_certs, sizeof(x509_bundle));
 
-    if (s_crt_bundle.crts == NULL) {
-        log_e("Unable to allocate memory for bundle");
-        return ESP_ERR_NO_MEM;
-    }
+  if (s_crt_bundle.crts == NULL) {
+    log_e("Unable to allocate memory for bundle");
+    return ESP_ERR_NO_MEM;
+  }
 
-    const uint8_t *cur_crt;
-    cur_crt = x509_bundle + BUNDLE_HEADER_OFFSET;
+  const uint8_t *cur_crt;
+  cur_crt = x509_bundle + BUNDLE_HEADER_OFFSET;
 
-    for (int i = 0; i < s_crt_bundle.num_certs; i++) {
-        s_crt_bundle.crts[i] = cur_crt;
+  for (int i = 0; i < s_crt_bundle.num_certs; i++) {
+    s_crt_bundle.crts[i] = cur_crt;
 
-        size_t name_len = cur_crt[0] << 8 | cur_crt[1];
-        size_t key_len = cur_crt[2] << 8 | cur_crt[3];
-        cur_crt = cur_crt + CRT_HEADER_OFFSET + name_len + key_len;
-    }
+    size_t name_len = cur_crt[0] << 8 | cur_crt[1];
+    size_t key_len = cur_crt[2] << 8 | cur_crt[3];
+    cur_crt = cur_crt + CRT_HEADER_OFFSET + name_len + key_len;
+  }
 
-    return ESP_OK;
+  return ESP_OK;
 }
 
-esp_err_t ssl_lib_crt_bundle_attach(void *conf)
-{
-    esp_err_t ret = ESP_OK;
-    // If no bundle has been set by the user then use the bundle embedded in the binary
-    if (s_crt_bundle.crts == NULL) {
-        log_e("Failed to attach bundle");
-        return ret;
-    }
-
-    if (conf) {
-        /* point to a dummy certificate
-         * This is only required so that the
-         * cacert_ptr passes non-NULL check during handshake
-         */
-        mbedtls_ssl_config *ssl_conf = (mbedtls_ssl_config *)conf;
-        mbedtls_x509_crt_init(&s_dummy_crt);
-        mbedtls_ssl_conf_ca_chain(ssl_conf, &s_dummy_crt, NULL);
-        mbedtls_ssl_conf_verify(ssl_conf, esp_crt_verify_callback, NULL);
-    }
-
+esp_err_t ssl_lib_crt_bundle_attach(void *conf) {
+  esp_err_t ret = ESP_OK;
+  // If no bundle has been set by the user then use the bundle embedded in the binary
+  if (s_crt_bundle.crts == NULL) {
+    log_e("Failed to attach bundle");
     return ret;
+  }
+
+  if (conf) {
+    /* point to a dummy certificate
+      * This is only required so that the
+      * cacert_ptr passes non-NULL check during handshake
+      */
+    mbedtls_ssl_config *ssl_conf = (mbedtls_ssl_config *)conf;
+    mbedtls_x509_crt_init(&s_dummy_crt);
+    mbedtls_ssl_conf_ca_chain(ssl_conf, &s_dummy_crt, NULL);
+    mbedtls_ssl_conf_verify(ssl_conf, esp_crt_verify_callback, NULL);
+  }
+
+  return ret;
 }
 
-void ssl_lib_crt_bundle_detach(mbedtls_ssl_config *conf)
-{
-    free(s_crt_bundle.crts);
-    s_crt_bundle.crts = NULL;
-    if (conf) {
-        mbedtls_ssl_conf_verify(conf, NULL, NULL);
-    }
+void ssl_lib_crt_bundle_detach(mbedtls_ssl_config *conf) {
+  free(s_crt_bundle.crts);
+  s_crt_bundle.crts = NULL;
+  if (conf) {
+    mbedtls_ssl_conf_verify(conf, NULL, NULL);
+  }
 }
 
-void ssl_lib_crt_bundle_set(const uint8_t *x509_bundle)
-{
-    // Free any previously used bundle
-    free(s_crt_bundle.crts);
-    esp_crt_bundle_init(x509_bundle);
+void ssl_lib_crt_bundle_set(const uint8_t *x509_bundle) {
+  // Free any previously used bundle
+  free(s_crt_bundle.crts);
+  esp_crt_bundle_init(x509_bundle);
 }

--- a/src/certBundle.h
+++ b/src/certBundle.h
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 
-#ifndef SSL_LIB_CRT_BUNDLE_H
-#define SSL_LIB_CRT_BUNDLE_H
+#ifndef CERT_BUNDLE_H
+#define CERT_BUNDLE_H
 
-#ifdef SSL_CLIENT_TEST_ENVIRONMENT
-#include "MbedTLS.h"
-#else
+#ifndef SSL_CLIENT_TEST_ENVIRONMENT
 #include "mbedtls/ssl.h"
+#else
+#include "MbedTLS.h"
 #endif
-
 #include "esp_err.h"
 
 #ifdef __cplusplus
@@ -42,7 +41,8 @@ extern "C" {
  *             - ESP_OK  if adding certificates was successful.
  *             - Other   if an error occured or an action must be taken by the calling process.
  */
-extern esp_err_t ssl_lib_crt_bundle_attach(void *conf);
+esp_err_t ssl_lib_crt_bundle_attach(void *conf);
+
 
 /**
  * @brief      Disable and dealloc the certification bundle
@@ -51,7 +51,7 @@ extern esp_err_t ssl_lib_crt_bundle_attach(void *conf);
  *
  * @param[in]  conf      The config struct for the SSL connection.
  */
-extern void ssl_lib_crt_bundle_detach(mbedtls_ssl_config *conf);
+void ssl_lib_crt_bundle_detach(mbedtls_ssl_config *conf);
 
 
 /**
@@ -63,7 +63,7 @@ extern void ssl_lib_crt_bundle_detach(mbedtls_ssl_config *conf);
  *
  * @param[in]  x509_bundle     A pointer to the certificate bundle.
  */
-extern void ssl_lib_crt_bundle_set(const uint8_t *x509_bundle);
+void ssl_lib_crt_bundle_set(const uint8_t *x509_bundle);
 
 
 #ifdef __cplusplus

--- a/src/ssl__client.cpp
+++ b/src/ssl__client.cpp
@@ -397,7 +397,8 @@ int init_tcp_connection(sslclient__context *ssl_client, const char *host, uint32
   log_v("Client pointer: %p", (void*) pClient);
 
   if (!pClient->connect(host, port)) {
-    log_e("Connection to server failed!");
+    log_e(
+      "Connection to server failed, is the signal good, server available at this address and timeout sufficient? %s:%d", host, port);
     return -2;
   }
 

--- a/src/ssl__client.cpp
+++ b/src/ssl__client.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <string>
 #include "ssl__client.h"
+#include "certBundle.h"
 
 //#define ARDUHAL_LOG_LEVEL 5
 //#include <esp32-hal-log.h>
@@ -128,10 +129,6 @@ int client_net_recv_timeout(void *ctx, unsigned char *buf, size_t len, uint32_t 
       break;
     }
   } while (millis() < tms);
-
-  if (timeout > 0 && millis() - start >= timeout) {
-    log_w("Timeout (%ums) reached, this can be caused by a slow network or a slow client, check underlying client.", timeout);
-  }
   
   int result = client->read(buf, len);
   
@@ -325,13 +322,13 @@ int start_ssl_client(
       break;
     }
     if (alpn_protos != NULL) {
-      log_i("Setting ALPN protocols");
+      log_v("Setting ALPN protocols");
       if ((ret = mbedtls_ssl_conf_alpn_protocols(&ssl_client->ssl_conf, alpn_protos) ) != 0) {
         return handle_error(ret);
       }
     }
     log_v("SSL config defaults set, ret: %d", ret);
-    ret = auth_root_ca_buff(ssl_client, rootCABuff, &ca_cert_initialized, pskIdent, psKey, insecure, useRootCABundle); // Step 4 route a - Set up required auth mode rootCaBuff
+    ret = auth_root_ca_buff(ssl_client, rootCABuff, &ca_cert_initialized, pskIdent, psKey, insecure); // Step 4 route a - Set up required auth mode rootCaBuff
     if (ret != 0) {
       break;
     }
@@ -355,9 +352,10 @@ int start_ssl_client(
     if (ret != 0) {
       break;
     }
-    ret = verify_server_cert(ssl_client); // Step 8 - Verify the server certificate
+    int flags = verify_server_cert(ssl_client); // Step 8 - Verify the server certificate
+    ret = flags;
     if (ret != 0) {
-      log_failed_cert(ret);
+      log_failed_cert(flags);
     } else {
       log_v("Certificate verified.");
     }
@@ -471,7 +469,7 @@ int set_up_tls_defaults(sslclient__context *ssl_client) {
  * If successful, the function returns 0; otherwise, it returns an error code, -1 for a null context.
  */
 int auth_root_ca_buff(sslclient__context *ssl_client, const char *rootCABuff, bool *ca_cert_initialized,
-                      const char *pskIdent, const char *psKey, bool insecure, bool useRootCABundle) {
+                      const char *pskIdent, const char *psKey, bool insecure) {
   if (ssl_client == nullptr) {
     log_e("Uninitialised context!");
     return -1;
@@ -500,15 +498,7 @@ int auth_root_ca_buff(sslclient__context *ssl_client, const char *rootCABuff, bo
       log_e("ca_cert_initialized is null!");
       return -1;
     }
-  } else if (useRootCABundle) {
-    log_v("Attaching root CA cert bundle");
-  #ifndef SSL_CLIENT_TEST_ENVIRONMENT // not available in test environment due to weird linker
-    ret = ssl_lib_crt_bundle_attach(&ssl_client->ssl_conf);
-  #endif
-
-    if (ret < 0) {
-      return handle_error(ret);
-    }
+    
   } else if (pskIdent != nullptr && psKey != nullptr) {
     log_v("Setting up PSK");
     
@@ -751,14 +741,10 @@ int perform_ssl_handshake(sslclient__context *ssl_client, const char *cli_cert, 
   }
 
   if (cli_cert != NULL && cli_key != NULL) {
-    log_v("Protocol is %s Ciphersuite is %s", mbedtls_ssl_get_version(&ssl_client->ssl_ctx), mbedtls_ssl_get_ciphersuite(&ssl_client->ssl_ctx));
-    ret = mbedtls_ssl_get_record_expansion(&ssl_client->ssl_ctx);
-    if (ret != 0) {
-      if (ret == MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE) {
-        log_w("Record expansion is not available (compression)");
-      } else {
-        log_e("mbedtls_ssl_get_record_expansion returned -0x%x", -ret);
-      }
+    log_d("Protocol is %s Ciphersuite is %s", mbedtls_ssl_get_version(&ssl_client->ssl_ctx), mbedtls_ssl_get_ciphersuite(&ssl_client->ssl_ctx));
+    int exp = mbedtls_ssl_get_record_expansion(&ssl_client->ssl_ctx);
+    if (exp >= 0) {
+      log_d("Record expansion is %d", exp);
     } else {
       log_w("Record expansion is unknown (compression)");
     }

--- a/src/ssl__client.h
+++ b/src/ssl__client.h
@@ -23,7 +23,6 @@
 #endif
 
 #include <Client.h>
-#include "certBundle.h"
 
 #define SSL_CLIENT_LOW_LATENCY_NETWORK_HANDSHAKE_TIMEOUT 5000U
 #define SSL_CLIENT_DEFAULT_HANDSHAKE_TIMEOUT 15000U
@@ -56,7 +55,7 @@ int start_ssl_client(sslclient__context *ssl_client, const char *host, uint32_t 
 int init_tcp_connection(sslclient__context *ssl_client, const char *host, uint32_t port);
 int seed_random_number_generator(sslclient__context *ssl_client);
 int set_up_tls_defaults(sslclient__context *ssl_client);
-int auth_root_ca_buff(sslclient__context *ssl_client, const char *rootCABuff, bool *ca_cert_initialized, const char *pskIdent, const char *psKey, bool insecure, bool useRootCABundle);
+int auth_root_ca_buff(sslclient__context *ssl_client, const char *rootCABuff, bool *ca_cert_initialized, const char *pskIdent, const char *psKey, bool insecure);
 int auth_client_cert_key(sslclient__context *ssl_client, const char *cli_cert, const char *cli_key, bool *client_cert_initialized, bool *client_key_initialized);
 int set_hostname_for_tls(sslclient__context *ssl_client, const char *host);
 int set_io_callbacks_and_timeout(sslclient__context *ssl_client, int timeout);


### PR DESCRIPTION
perform handshake function call being erroneously set form return value of get record expansion. If get record expansion is called this means we have already established the secure connection. We need only check record expansion for handling buffer sizes after this. Closes #71 #63 #62 #68 