### PR TITLE
Hotfix to porting library to arduino-esp32 v3

### DIFF
--- a/src/SSLClient.cpp
+++ b/src/SSLClient.cpp
@@ -93,7 +93,7 @@ SSLClient::~SSLClient() {
  */
 void SSLClient::stop() {
   if (sslclient->client != nullptr) {
-    if (sslclient->client >= 0) {
+    if (sslclient->client >= (void*)0) {
       log_d("Stopping ssl client");
       stop_ssl_socket(sslclient, _CA_cert, _cert, _private_key);
     } else {

--- a/src/certBundle.c
+++ b/src/certBundle.c
@@ -53,20 +53,20 @@ static int esp_crt_check_signature(mbedtls_x509_crt *child, const uint8_t *pub_k
 
 
   // Fast check to avoid expensive computations when not necessary
-  if (!mbedtls_pk_can_do(&parent.pk, child->sig_pk)) {
+  if (!mbedtls_pk_can_do(&parent.pk, child->private_sig_pk)) {
     log_e("Simple compare failed");
     ret = -1;
     goto cleanup;
   }
 
-  md_info = mbedtls_md_info_from_type(child->sig_md);
+  md_info = mbedtls_md_info_from_type(child->private_sig_md);
   if ( (ret = mbedtls_md( md_info, child->tbs.p, child->tbs.len, hash )) != 0 ) {
     log_e("Internal mbedTLS error %X", ret);
     goto cleanup;
   }
 
-  if ((ret = mbedtls_pk_verify_ext(child->sig_pk, child->sig_opts, &parent.pk, child->sig_md, hash, mbedtls_md_get_size( md_info ),
-                                   child->sig.p, child->sig.len )) != 0 ) {
+  if ((ret = mbedtls_pk_verify_ext(child->private_sig_pk, child->private_sig_opts, &parent.pk, child->private_sig_md, hash, mbedtls_md_get_size( md_info ),
+                                   child->private_sig.p, child->private_sig.len )) != 0 ) {
       log_e("PK verify failed with error %X", ret);
       goto cleanup;
   }

--- a/src/certBundle.c
+++ b/src/certBundle.c
@@ -59,14 +59,22 @@ static int esp_crt_check_signature(mbedtls_x509_crt *child, const uint8_t *pub_k
     goto cleanup;
   }
 
+#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
   md_info = mbedtls_md_info_from_type(child->private_sig_md);
+#else
+  md_info = mbedtls_md_info_from_type(child->sig_md);
+#endif
   if ( (ret = mbedtls_md( md_info, child->tbs.p, child->tbs.len, hash )) != 0 ) {
     log_e("Internal mbedTLS error %X", ret);
     goto cleanup;
   }
-
+#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
   if ((ret = mbedtls_pk_verify_ext(child->private_sig_pk, child->private_sig_opts, &parent.pk, child->private_sig_md, hash, mbedtls_md_get_size( md_info ),
                                    child->private_sig.p, child->private_sig.len )) != 0 ) {
+#else
+  if ((ret = mbedtls_pk_verify_ext(child->sig_pk, child->sig_opts, &parent.pk, child->sig_md, hash, mbedtls_md_get_size( md_info ),
+                                   child->sig.p, child->sig.len )) != 0 ) {
+#endif
       log_e("PK verify failed with error %X", ret);
       goto cleanup;
   }

--- a/src/certBundle.c
+++ b/src/certBundle.c
@@ -53,7 +53,11 @@ static int esp_crt_check_signature(mbedtls_x509_crt *child, const uint8_t *pub_k
 
 
   // Fast check to avoid expensive computations when not necessary
+#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
   if (!mbedtls_pk_can_do(&parent.pk, child->private_sig_pk)) {
+#else
+  if (!mbedtls_pk_can_do(&parent.pk, child->sig_pk)) {
+#endif
     log_e("Simple compare failed");
     ret = -1;
     goto cleanup;

--- a/src/certBundle.c
+++ b/src/certBundle.c
@@ -53,7 +53,7 @@ static int esp_crt_check_signature(mbedtls_x509_crt *child, const uint8_t *pub_k
 
 
   // Fast check to avoid expensive computations when not necessary
-#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
+#if (MBEDTLS_VERSION_MAJOR  >= 3)
   if (!mbedtls_pk_can_do(&parent.pk, child->private_sig_pk)) {
 #else
   if (!mbedtls_pk_can_do(&parent.pk, child->sig_pk)) {
@@ -63,7 +63,7 @@ static int esp_crt_check_signature(mbedtls_x509_crt *child, const uint8_t *pub_k
     goto cleanup;
   }
 
-#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
+#if (MBEDTLS_VERSION_MAJOR  >= 3)
   md_info = mbedtls_md_info_from_type(child->private_sig_md);
 #else
   md_info = mbedtls_md_info_from_type(child->sig_md);
@@ -72,7 +72,7 @@ static int esp_crt_check_signature(mbedtls_x509_crt *child, const uint8_t *pub_k
     log_e("Internal mbedTLS error %X", ret);
     goto cleanup;
   }
-#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
+#if (MBEDTLS_VERSION_MAJOR  >= 3)
   if ((ret = mbedtls_pk_verify_ext(child->private_sig_pk, child->private_sig_opts, &parent.pk, child->private_sig_md, hash, mbedtls_md_get_size( md_info ),
                                    child->private_sig.p, child->private_sig.len )) != 0 ) {
 #else

--- a/src/ssl__client.cpp
+++ b/src/ssl__client.cpp
@@ -815,14 +815,14 @@ void stop_ssl_socket(sslclient__context *ssl_client, const char *rootCABuff, con
     ssl_client->client->stop();
   }
 
-  if (ssl_client->ssl_conf.ca_chain != NULL) {
+  if (ssl_client->ssl_conf.private_ca_chain != NULL) {
     log_d("Freeing CA cert. Current ca_cert address: %p", (void *)&ssl_client->ca_cert);
 
     // Free the memory associated with the CA certificate
     mbedtls_x509_crt_free(&ssl_client->ca_cert);
   }
 
-  if (ssl_client->ssl_conf.key_cert != NULL) {
+  if (ssl_client->ssl_conf.private_key_cert != NULL) {
     log_d("Freeing client cert and client key. Current client_cert address: %p, client_key address: %p", 
           (void *)&ssl_client->client_cert, (void *)&ssl_client->client_key);
 

--- a/src/ssl__client.cpp
+++ b/src/ssl__client.cpp
@@ -576,7 +576,7 @@ int auth_client_cert_key(sslclient__context *ssl_client, const char *cli_cert, c
     }
 
     log_v("Loading private key");
-    ret = mbedtls_pk_parse_key(&ssl_client->client_key, (const unsigned char *)cli_key, strlen(cli_key) + 1, NULL, 0);
+    ret = mbedtls_pk_parse_key(&ssl_client->client_key, (const unsigned char *)cli_key, strlen(cli_key) + 1, NULL, 0, NULL, NULL);
     if (ret != 0) { // PK or PEM non-zero error codes
       mbedtls_x509_crt_free(&ssl_client->client_cert); // cert+key are free'd in pair
       return ret;

--- a/src/ssl__client.cpp
+++ b/src/ssl__client.cpp
@@ -576,7 +576,7 @@ int auth_client_cert_key(sslclient__context *ssl_client, const char *cli_cert, c
     }
 
     log_v("Loading private key");
-#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
+#if (MBEDTLS_VERSION_MAJOR  >= 3)
     mbedtls_ctr_drbg_context ctr_drbg;
     mbedtls_ctr_drbg_init(&ctr_drbg);
     ret = mbedtls_pk_parse_key(&ssl_client->client_key, (const unsigned char *)cli_key, strlen(cli_key) + 1, NULL, 0, mbedtls_ctr_drbg_random, &ctr_drbg);
@@ -821,7 +821,7 @@ void stop_ssl_socket(sslclient__context *ssl_client, const char *rootCABuff, con
     log_d("Stopping SSL client. Current client pointer address: %p", (void *)ssl_client->client);
     ssl_client->client->stop();
   }
-#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
+#if (MBEDTLS_VERSION_MAJOR  >= 3)
   if (ssl_client->ssl_conf.private_ca_chain != NULL) {
 #else
   if (ssl_client->ssl_conf.ca_chain != NULL) {
@@ -831,7 +831,7 @@ void stop_ssl_socket(sslclient__context *ssl_client, const char *rootCABuff, con
     // Free the memory associated with the CA certificate
     mbedtls_x509_crt_free(&ssl_client->ca_cert);
   }
-#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
+#if (MBEDTLS_VERSION_MAJOR  >= 3)
   if (ssl_client->ssl_conf.private_key_cert != NULL) {
 #else
   if (ssl_client->ssl_conf.key_cert != NULL) {

--- a/src/ssl__client.cpp
+++ b/src/ssl__client.cpp
@@ -576,10 +576,14 @@ int auth_client_cert_key(sslclient__context *ssl_client, const char *cli_cert, c
     }
 
     log_v("Loading private key");
+#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
     mbedtls_ctr_drbg_context ctr_drbg;
     mbedtls_ctr_drbg_init(&ctr_drbg);
     ret = mbedtls_pk_parse_key(&ssl_client->client_key, (const unsigned char *)cli_key, strlen(cli_key) + 1, NULL, 0, mbedtls_ctr_drbg_random, &ctr_drbg);
     mbedtls_ctr_drbg_free(&ctr_drbg);
+#else
+    ret = mbedtls_pk_parse_key(&ssl_client->client_key, (const unsigned char *)cli_key, strlen(cli_key) + 1, NULL, 0);
+#endif
     if (ret != 0) { // PK or PEM non-zero error codes
       mbedtls_x509_crt_free(&ssl_client->client_cert); // cert+key are free'd in pair
       return ret;
@@ -817,15 +821,21 @@ void stop_ssl_socket(sslclient__context *ssl_client, const char *rootCABuff, con
     log_d("Stopping SSL client. Current client pointer address: %p", (void *)ssl_client->client);
     ssl_client->client->stop();
   }
-
+#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
   if (ssl_client->ssl_conf.private_ca_chain != NULL) {
+#else
+  if (ssl_client->ssl_conf.ca_chain != NULL) {
+#endif
     log_d("Freeing CA cert. Current ca_cert address: %p", (void *)&ssl_client->ca_cert);
 
     // Free the memory associated with the CA certificate
     mbedtls_x509_crt_free(&ssl_client->ca_cert);
   }
-
+#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
   if (ssl_client->ssl_conf.private_key_cert != NULL) {
+#else
+  if (ssl_client->ssl_conf.key_cert != NULL) {
+#endif
     log_d("Freeing client cert and client key. Current client_cert address: %p, client_key address: %p", 
           (void *)&ssl_client->client_cert, (void *)&ssl_client->client_key);
 

--- a/src/ssl__client.cpp
+++ b/src/ssl__client.cpp
@@ -576,7 +576,10 @@ int auth_client_cert_key(sslclient__context *ssl_client, const char *cli_cert, c
     }
 
     log_v("Loading private key");
-    ret = mbedtls_pk_parse_key(&ssl_client->client_key, (const unsigned char *)cli_key, strlen(cli_key) + 1, NULL, 0, NULL, NULL);
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+    ret = mbedtls_pk_parse_key(&ssl_client->client_key, (const unsigned char *)cli_key, strlen(cli_key) + 1, NULL, 0, mbedtls_ctr_drbg_random, &ctr_drbg);
+    mbedtls_ctr_drbg_free(&ctr_drbg);
     if (ret != 0) { // PK or PEM non-zero error codes
       mbedtls_x509_crt_free(&ssl_client->client_cert); // cert+key are free'd in pair
       return ret;

--- a/src/ssl__client.h
+++ b/src/ssl__client.h
@@ -12,7 +12,7 @@
 #include <mbedtls/platform.h>
 #include <mbedtls/sha256.h>
 #include <mbedtls/oid.h>
-#include <mbedtls/net.h>
+#include <mbedtls/net_sockets.h>
 #include <mbedtls/debug.h>
 #include <mbedtls/ssl.h>
 #include <mbedtls/entropy.h>

--- a/src/ssl__client.h
+++ b/src/ssl__client.h
@@ -12,7 +12,7 @@
 #include <mbedtls/platform.h>
 #include <mbedtls/sha256.h>
 #include <mbedtls/oid.h>
-#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
+#if (MBEDTLS_VERSION_MAJOR  >= 3)
 #include <mbedtls/net_sockets.h>
 #else
 #include <mbedtls/net.h>

--- a/src/ssl__client.h
+++ b/src/ssl__client.h
@@ -12,7 +12,11 @@
 #include <mbedtls/platform.h>
 #include <mbedtls/sha256.h>
 #include <mbedtls/oid.h>
+#if (ESP_ARDUINO_VERSION_MAJOR  >= 3)
 #include <mbedtls/net_sockets.h>
+#else
+#include <mbedtls/net.h>
+#endif
 #include <mbedtls/debug.h>
 #include <mbedtls/ssl.h>
 #include <mbedtls/entropy.h>


### PR DESCRIPTION
This pull request fixes issue #83 , as Espressif has introduced a new version of MbedTLS into their framework. This in term breaks compatibility with the current version of SSLClient. These changes are not backwards compatible with arduino-esp32 v2